### PR TITLE
Enable ipv6 support

### DIFF
--- a/plugin/httpserver.py
+++ b/plugin/httpserver.py
@@ -16,7 +16,7 @@ from twisted.internet.error import CannotListenError
 
 from controllers.root import RootController
 from sslcertificate import SSLCertificateGenerator, KEY_FILE, CERT_FILE
-from socket import gethostname
+from socket import gethostname, has_ipv6
 
 import os
 import imp
@@ -116,9 +116,12 @@ def HttpdStart(session):
 		
 		# start http webserver on configured port
 		try:
-			listener.append( reactor.listenTCP(port, site) )
-#			if socket.has_ipv6 and fileExists('/proc/net/if_inet6'):
-#				listener.append( reactor.listenTCP(port, site, interface='::') )			
+			if has_ipv6 and fileExists('/proc/net/if_inet6'):
+				# use ipv6
+				listener.append( reactor.listenTCP(port, site, interface='::') )
+			else:
+				# ipv4 only
+				listener.append( reactor.listenTCP(port, site) )
 			print "[OpenWebif] started on %i"% (port)
 		except CannotListenError:
 			print "[OpenWebif] failed to listen on Port %i" % (port)
@@ -129,9 +132,12 @@ def HttpdStart(session):
 			# start https webserver on port configured port
 			try:
 				context = ssl.DefaultOpenSSLContextFactory(KEY_FILE, CERT_FILE)
-				listener.append( reactor.listenSSL(httpsPort, site, context) )
-#				if socket.has_ipv6 and fileExists('/proc/net/if_inet6'):
-#					listener.append( reactor.listenSSL(httpsPort, site, context, interface='::') )
+				if has_ipv6 and fileExists('/proc/net/if_inet6'):
+					# use ipv6
+					listener.append( reactor.listenSSL(httpsPort, site, context, interface='::') )
+				else:
+					# ipv4 only
+					listener.append( reactor.listenSSL(httpsPort, site, context) )
 				print "[OpenWebif] started on", httpsPort
 			except CannotListenError:
 				print "[OpenWebif] failed to listen on Port", httpsPort
@@ -142,9 +148,12 @@ def HttpdStart(session):
 				root = buildRootTree(session)
 				site = server.Site(root)
 				try:
-					listener.append( reactor.listenTCP(80, site, interface='127.0.0.1') )
-#					if socket.has_ipv6 and fileExists('/proc/net/if_inet6'):
-#						listener.append( reactor.listenTCP(80, site, interface='::1') )
+					if has_ipv6 and fileExists('/proc/net/if_inet6'):
+						# use ipv6
+						listener.append( reactor.listenTCP(80, site, interface='::1') )
+					else:
+						# ipv4 only
+						listener.append( reactor.listenTCP(80, site, interface='127.0.0.1') )
 					print "[OpenWebif] started stream listening on port 80"
 				except CannotListenError:
 					print "[OpenWebif] port 80 busy"


### PR DESCRIPTION
Each port can be opened only once, if opened in ipv6 mode it will work automatically in ipv4 too. I tested this on my ipv6 enabled box, obviously it needs testing on an ipv4-only box before accepting.
