### PR TITLE
Fix Mobile Interface Display Nane and Zap

### DIFF
--- a/plugin/controllers/mobile.py
+++ b/plugin/controllers/mobile.py
@@ -48,12 +48,16 @@ class MobileController(BaseController):
 		channelepg = {}
 		if "sref" in request.args.keys():
 			sref=request.args["sref"][0]
-			# Detect if sRef contains a stream (Never has EPG, always gets borked)
-			if (sref.split(':', 2)[0] == "4097"):
+			channelepg = getChannelEpg(sref)
+			# Detect if sRef contains a stream
+			if ("://" in sref):
 				# Repair sRef (URL part gets unquoted somewhere in between but MUST NOT)
 				sref = ":".join(sref.split(':')[:10]) + ":" + quote(":".join(sref.split(':')[10:-1])) + ":" + sref.split(':')[-1]
 				# Get service name from last part of the sRef
 				channelinfo['sname'] = sref.split(':')[-1]
+				# Use quoted sref when stream has EPG
+				if len(channelepg['events']) > 1:
+					channelepg["events"][0]["sref"] = sref
 			else:
 				# todo: Get service name
 				channelinfo['sname'] = ""
@@ -65,7 +69,6 @@ class MobileController(BaseController):
 			channelinfo['longdesc'] = ""
 			channelinfo['begin'] = 0
 			channelinfo['end'] = 0
-			channelepg = getChannelEpg(request.args["sref"][0])
 			
 		# Got EPG information?
 		if len(channelepg['events']) > 1:

--- a/plugin/controllers/models/services.py
+++ b/plugin/controllers/models/services.py
@@ -452,12 +452,17 @@ def getEvent(ref, idev):
 
 
 def getChannelEpg(ref, begintime=-1, endtime=-1):
-	ref = unquote(ref)
+	tmpref = unquote(ref)
 	ret = []
 	ev = {}
 	picon = getPicon(ref)
 	epgcache = eEPGCache.getInstance()
-	events = epgcache.lookupEvent(['IBDTSENC', (ref, 0, begintime, endtime)])
+
+	# Wnen quering EPG we dont need URL
+	if "://" in tmpref:
+		tmpref = ":".join(tmpref.split(":")[:10]) + "::" + tmpref.split(":")[-1]
+
+	events = epgcache.lookupEvent(['IBDTSENC', (tmpref, 0, begintime, endtime)])
 	if events is not None:
 		for event in events:
 			ev = {}


### PR DESCRIPTION
4097 services can contain EPG after latest changes in OpenPLi (and all images pulling updates from OpenPLi).
When 4097 service contain EPG sref is not quoted. Also we souldn't to pass URL data when querying for EPG data.
Finally identify URL from "://" and not from 4097 service.

Here is screenshot without patch:

![service_name](https://f.cloud.github.com/assets/2682247/1749310/02f3ac40-650a-11e3-97b5-205edcdc6d63.png)

And here with:

![service_name_with_patch](https://f.cloud.github.com/assets/2682247/1749309/fca181f0-6509-11e3-9acb-549f120963f9.png)
