### PR TITLE
Fix Mobile Interface Display Nane, Zap and Picon

### DIFF
--- a/plugin/controllers/mobile.py
+++ b/plugin/controllers/mobile.py
@@ -48,12 +48,16 @@ class MobileController(BaseController):
 		channelepg = {}
 		if "sref" in request.args.keys():
 			sref=request.args["sref"][0]
-			# Detect if sRef contains a stream (Never has EPG, always gets borked)
-			if (sref.split(':', 2)[0] == "4097"):
+			channelepg = getChannelEpg(sref)
+			# Detect if sRef contains a stream
+			if ("://" in sref):
 				# Repair sRef (URL part gets unquoted somewhere in between but MUST NOT)
 				sref = ":".join(sref.split(':')[:10]) + ":" + quote(":".join(sref.split(':')[10:-1])) + ":" + sref.split(':')[-1]
 				# Get service name from last part of the sRef
 				channelinfo['sname'] = sref.split(':')[-1]
+				# Use quoted sref when stream has EPG
+				if len(channelepg['events']) > 1:
+					channelepg['events'][0]['sref'] = sref
 			else:
 				# todo: Get service name
 				channelinfo['sname'] = ""
@@ -65,7 +69,6 @@ class MobileController(BaseController):
 			channelinfo['longdesc'] = ""
 			channelinfo['begin'] = 0
 			channelinfo['end'] = 0
-			channelepg = getChannelEpg(request.args["sref"][0])
 			
 		# Got EPG information?
 		if len(channelepg['events']) > 1:

--- a/plugin/controllers/models/services.py
+++ b/plugin/controllers/models/services.py
@@ -455,6 +455,11 @@ def getChannelEpg(ref, begintime=-1, endtime=-1):
 	ref = unquote(ref)
 	ret = []
 	ev = {}
+
+	# Wnen quering EPG we dont need URL, also getPicon doesn't like URL
+	if "://" in ref:
+		ref = ":".join(ref.split(":")[:10]) + "::" + ref.split(":")[-1]
+
 	picon = getPicon(ref)
 	epgcache = eEPGCache.getInstance()
 	events = epgcache.lookupEvent(['IBDTSENC', (ref, 0, begintime, endtime)])


### PR DESCRIPTION
4097 services can contain EPG after latest changes in OpenPLi (and all images pulling updates from OpenPLi).
When 4097 service contain EPG sref is not quoted.
Also we souldn't to pass URL data when querying for EPG data and picon.
Finally identify URL from "://" and not from 4097 service.

Here is screenshot without patch:

![service_name](https://f.cloud.github.com/assets/2682247/1749916/be445f3a-6555-11e3-905f-a0b3a46a6f28.png)

And here with:

![service_name_and_picon_with_patch](https://f.cloud.github.com/assets/2682247/1749917/ccf0fbd8-6555-11e3-97c9-8eb1d2f5dc55.png)
