### PR TITLE
Fix getPicon to return correct picon for streams

### DIFF
--- a/plugin/controllers/models/services.py
+++ b/plugin/controllers/models/services.py
@@ -733,6 +733,13 @@ def getMultiEpg(self, ref, begintime=-1, endtime=None):
 	return { "events": ret, "result": True, "picons": picons }
 
 def getPicon(sname):
+	# sname can be quoted
+	sname = unquote(sname)
+
+	# remove URL part
+	if "://" in sname:
+		sname = ":".join(sname.split(":")[:10]) + "::" + sname.split(":")[-1]
+
 	sname = GetWithAlternative(sname)
 	if sname is not None:
 		pos = sname.rfind(':')


### PR DESCRIPTION
getPicon doen't like url part of service reference, so remove it.
Also service reference can be quoted, unquote.

Without patch:

![without_picon_current](https://f.cloud.github.com/assets/2682247/1749976/850eb932-655e-11e3-8b17-a8b1fcc777c5.png)

![without_picon_epg](https://f.cloud.github.com/assets/2682247/1749977/8513e3bc-655e-11e3-8376-8ba471414abf.png)

With patch:

![with_picon_current](https://f.cloud.github.com/assets/2682247/1749978/85184b8c-655e-11e3-88c7-b29dc6c10d52.png)

![with_picon_epg](https://f.cloud.github.com/assets/2682247/1749975/84da0a16-655e-11e3-9aba-58674414ccf2.png)
