### PR TITLE
Grab: Arbitary code execution

### DIFF
--- a/plugin/controllers/models/grab.py
+++ b/plugin/controllers/models/grab.py
@@ -35,10 +35,12 @@ class grabScreenshot(resource.Resource):
 			graboptions += " -j 100"
 		elif self.fileformat == "png":
 			graboptions += " -p"
+		elif self.fileformat != "bmp":
+			self.fileformat = "bmp"
 
 		if "r" in request.args.keys():
 			size = request.args["r"][0]
-			graboptions += " -r %s" % size
+			graboptions += " -r %s" % int(size)
 
 		if "mode" in request.args.keys():
 			mode = request.args["mode"][0]


### PR DESCRIPTION
Grab suffers from arbitary code execution because it doesn't validate arguments passed to grab.

Proof of Concept:

```
http://IP/grab?format=jpg&r=10000%20||%20echo%20root:12345%20|%20chpasswd%20||&mode=all&timestamp=12345
```
