### PR TITLE
Adding channel name to m3u file.

### DIFF
--- a/plugin/controllers/models/stream.py
+++ b/plugin/controllers/models/stream.py
@@ -43,7 +43,8 @@ def getStream(session, request, m3ufile):
 	# #EXTINF:-1,%s\n adding back to show service name in programs like VLC
 	progopt = ''
 	if config.OpenWebif.service_name_for_stream.value and sRef != '':
-		progopt="#EXTVLCOPT:program=%d\n" % (int(sRef.split(':')[3],16))
+		# When you use more than 1 EXTVLCOPT, it does not play stream
+		progopt="program=%d\n" % (int(sRef.split(':')[3],16))
 		progopt="%s#EXTINF:-1,%s\n" % (progopt, name)
 	portNumber = config.OpenWebif.streamport.value
 	info = getInfo()
@@ -54,7 +55,7 @@ def getStream(session, request, m3ufile):
 				portNumber = 8002
 	if "port" in request.args:
 		portNumber = request.args["port"][0]
-	response = "#EXTM3U \n#EXTVLCOPT--http-reconnect=true \n%shttp://%s:%s/%s\n" % (progopt,request.getRequestHostname(), portNumber, sRef)
+	response = "#EXTM3U \n#EXTVLCOPT--http-reconnect=true %shttp://%s:%s/%s\n" % (progopt,request.getRequestHostname(), portNumber, sRef)
 	request.setHeader('Content-Type', 'application/text')
 	return response
 


### PR DESCRIPTION
VLC and other external players can use this to display the stream name.
