### PR TITLE
Fix a RuntimeError in grabFinished

### DIFF
--- a/plugin/controllers/models/grab.py
+++ b/plugin/controllers/models/grab.py
@@ -88,6 +88,9 @@ class grabScreenshot(resource.Resource):
 			os.unlink(self.filepath)
 		except:
 			print "Failed to remove:", self.filepath
-		self.request.finish()
+		try:
+			self.request.finish()
+		except RuntimeError, error:
+			print "[OpenWebif] grabFinished error: %s" % error
 		del self.request
 		del self.filepath


### PR DESCRIPTION
When calling requst.finish and connection is gone the Enigma2 crashes withe the following error:

Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Plugins/Extensions/OpenWebif/controllers/models/grab.py", line 91, in grabFinished
    self.request.finish()
  File "/usr/lib/python2.7/site-packages/twisted/web/server.py", line 228, in finish
  File "/usr/lib/python2.7/site-packages/twisted/web/http.py", line 929, in finish
RuntimeError: Request.finish called on a request after its connection was lost; use Request.notifyFinish to keep track of this.

Handle that error and print a notification instead.
