### PR TITLE
Error deleting movies/recordings with single quotes in their name

### DIFF
--- a/plugin/controllers/views/ajax/movies.tmpl
+++ b/plugin/controllers/views/ajax/movies.tmpl
@@ -52,10 +52,11 @@
 							</div></div>
 						#end if
 						<br>
+						#set $eventname_escaped =  $movie.eventname.replace("'", r"\'")
 						<a href='/file?action=download&file=$quote($movie.filename)' title="$tstrings['download'] $movie.eventname"><div class="ow_i ow_i_save"></div></a>
 						<a href='#' onClick="alert('comming soon');" title="$tstrings['rename_recording']"><div class="ow_i ow_i_edit"></div></a>
-						<a href='#' onClick="deleteMovie('$quote($movie.serviceref)', '$count', '$movie.eventname'); return false;" title="$tstrings['delete_recording']"><div class="ow_i ow_i_delete"></div></a>
-						
+						<a href='#' onClick="deleteMovie('$quote($movie.serviceref)', '$count', '$eventname_escaped'); return false;" title="$tstrings['delete_recording']"><div class="ow_i ow_i_delete"></div></a>
+
 						</div>
 						</div>
 					#if $movie.eventname != ""


### PR DESCRIPTION
This pull request adds an escaped escaped version of the movie title to the `ajax/movies.tmpl` template in order to fix a js error that prevents movies with a single quote in their title from being deleted.