### PR TITLE
base.py: getRcFolder might missing although boxbranding exists

### DIFF
--- a/plugin/controllers/base.py
+++ b/plugin/controllers/base.py
@@ -24,14 +24,14 @@ import json
 import gzip
 import cStringIO
 
-remotesuffix=''
+remote=''
 try:
 	from boxbranding import getBoxType, getMachineName
 	from Components.RcModel import rc_model
-	remotesuffix = "/remote"
+	remote = rc_model.getRcFolder() + "/remote"
 except:
 	from models.owibranding import getBoxType, getMachineName, rc_model
-	rc_model = rc_model()
+	remote = rc_model().getRcFolder()
 
 class BaseController(resource.Resource):
 	isLeaf = False
@@ -197,7 +197,7 @@ class BaseController(resource.Resource):
 		if not ret['boxname'] or not ret['customname']:
 			ret['boxname'] = getInfo()['brand']+" "+getInfo()['model']
 		ret['box'] = getBoxType()
-		ret["remote"] = rc_model.getRcFolder()+remotesuffix
+		ret["remote"] = remote
 
 		extras = []
 		extras.append({ 'key': 'ajax/settings','description': _("Settings")})


### PR DESCRIPTION
OpenPLi doesn't contain getRcForlder (http://sourceforge.net/p/openpli/enigma2/ci/master/tree/lib/python/Components/RcModel.py)

  File "/usr/lib/python2.7/site-packages/twisted/web/server.py", line 189, in process
  File "/usr/lib/python2.7/site-packages/twisted/web/server.py", line 238, in render
  File "/usr/lib/enigma2/python/Plugins/Extensions/OpenWebif/controllers/base.py", line 151, in render
    args = self.prepareMainTemplate()
  File "/usr/lib/enigma2/python/Plugins/Extensions/OpenWebif/controllers/base.py", line 200, in prepareMainTemplate
    ret["remote"] = rc_model.getRcFolder()+remotesuffix
exceptions.AttributeError: RcModel instance has no attribute 'getRcFolder'

Call getRcFolder inside try and use as failback the OWIF getRcFolder...