### PR TITLE
BouquetEditor: backup user settings if they exist

### DIFF
--- a/plugin/controllers/BouquetEditor.py
+++ b/plugin/controllers/BouquetEditor.py
@@ -559,9 +559,9 @@ class BouquetEditor(Source):
 			files.append("/etc/enigma2/userbouquet.favourites.tv")
 			files.append("/etc/enigma2/userbouquet.favourites.radio")
 			files.append("/etc/enigma2/lamedb")
-			files.append("/etc/tuxbox/cables.xml")
-			files.append("/etc/tuxbox/terrestrial.xml")
-			files.append("/etc/tuxbox/satellites.xml")
+			for xml in ("/etc/enigma2/cables.xml", "/etc/enigma2/terrestrial.xml", "/etc/enigma2/satellites.xml", "/etc/tuxbox/cables.xml", "/etc/tuxbox/terrestrial.xml", "/etc/tuxbox/satellites.xml"):
+				if path.exists(xml):
+					files.append(xml)
 			if config.ParentalControl.configured.value:
 				if config.ParentalControl.type.value == "blacklist":
 					files.append("/etc/enigma2/blacklist")


### PR DESCRIPTION
Until now BouquetEditor backups only cables/terrestrial/satellites xml
files only if the exists on image location and only if all of the exist.

Back them only if they do exist (Eg a cable only machine doesn't need
terrestrial or satellites xml to be present in order to work)

Backup also user xml files under /etc/enigma2 if they exist (Eg under
OpenPLi we can create our cables/terrestrial/satellites xml that will
be used by Enigma2 if they exist instead of using default ones.