### PR TITLE
Formatted sref with colons instead of underscores. Useful for epg gra…

### DIFF
--- a/plugin/controllers/models/services.py
+++ b/plugin/controllers/models/services.py
@@ -108,7 +108,7 @@ def getCurrentFullInfo(session):
 		ref = None
 
 	if ref is not None:
-		inf['sref'] = '_'.join(ref.split(':', 10)[:10])
+		inf['sref'] = ':'.join(ref.split(':', 10)[:10]) + ':'
 		inf['picon'] = getPicon(ref)
 		inf['wide'] = inf['aspect'] in (3, 4, 7, 8, 0xB, 0xC, 0xF, 0x10)
 		inf['ttext'] = getServiceInfoString(info, iServiceInformation.sTXTPID)


### PR DESCRIPTION
It should be formatted this way for easy copy/paste EPG channels mappings. 
