### PR TITLE
Change time frame shown in multi epg when no day is selected

### DIFF
--- a/plugin/controllers/models/services.py
+++ b/plugin/controllers/models/services.py
@@ -766,6 +766,18 @@ def getMultiEpg(self, ref, begintime=-1, endtime=None):
 			if not timerlist.has_key(str(timer.service_ref)):
 				timerlist[str(timer.service_ref)] = []
 			timerlist[str(timer.service_ref)].append(timer)
+		
+		if begintime == -1:
+			# If no start time is requested, use current time as start time and extend
+			# show all events until 6:00 next day
+			bt = localtime()
+			offset = mktime( (bt.tm_year, bt.tm_mon, bt.tm_mday, bt.tm_hour - bt.tm_hour%2, 0,0, -1,-1,-1) )
+			lastevent = mktime( (bt.tm_year, bt.tm_mon, bt.tm_mday, 23, 59, 0, -1, -1, -1) ) + 6*3600
+		else:
+			# If a start time is requested, show all events in a 24 hour frame
+			bt = localtime(begintime)
+			offset = mktime( (bt.tm_year, bt.tm_mon, bt.tm_mday, bt.tm_hour - bt.tm_hour%2, 0,0, -1,-1,-1) )
+			lastevent = offset + 86399
 
 		for event in events:
 			ev = {}
@@ -780,14 +792,6 @@ def getMultiEpg(self, ref, begintime=-1, endtime=None):
 			if not ret.has_key(channel):
 				ret[channel] = [ [], [], [], [], [], [], [], [], [], [], [], [] ]
 				picons[channel] = getPicon(event[4])
-
-			if offset is None:
-				bt = event[1]
-				if begintime > event[1]:
-					bt = begintime
-				et = localtime(bt)
-				offset = mktime( (et.tm_year, et.tm_mon, et.tm_mday, 0, 0, 0, -1, -1, -1) )
-				lastevent = mktime( (et.tm_year, et.tm_mon, et.tm_mday, 23, 59, 0, -1, -1, -1) )
 
 			slot = int((event[1]-offset) / 7200)
 			if slot > -1 and slot < 12 and event[1] < lastevent:

--- a/plugin/controllers/views/ajax/multiepg2.tmpl
+++ b/plugin/controllers/views/ajax/multiepg2.tmpl
@@ -31,6 +31,7 @@ tr { vertical-align: top }
 .title { font-weight: bold; color: #061c37; }
 .desc { font-size: 10px; color: #176093; }
 .even { background-color: #dfeffc; }
+.odd { background-color: #fff; }
 .border { border-right: 1px solid #4297d7; }
 .event { cursor: pointer; width: 190px; overflow:hidden; }
 .bq { background-color: #1c478e; font-size: 11px; font-weight: bold; color: #fff; padding: 2px 4px; line-height: 18px; cursor: pointer; white-space: nowrap; display: inline-block; margin: 1px 1px; }


### PR DESCRIPTION
This patch changes behaviour of multi epg when no day is selected; it shows all events from now until 6:00 next day, but doesn't touch behaviour of multi epg when a specific day is requested.

The issue with the current behaviour is that it shows only very few events when you use it late in the evening. I expect it to show at least the current night's events.

And sorry for the inconvenience with the previous pull request.