### PR TITLE
Revert "Fix Edision OSmini detection"

### DIFF
--- a/plugin/controllers/models/owibranding.py
+++ b/plugin/controllers/models/owibranding.py
@@ -156,14 +156,6 @@ def getAllInfo():
 		procmodel = f.readline().strip()
 		f.close()
 		model = procmodel.title().replace("olose", "olo SE").replace("olo2se", "olo2 SE").replace("2", "²")
-		if fileExists("/proc/stb/info/boxtype"):
-			f = open("/proc/stb/info/boxtype",'r')
-			p = f.readline().strip().lower()
-			f.close()
-			if p == "osmini":
-				brand = "Edision"
-				model = "OS mini"
-				procmodel = p
 	elif fileExists("/proc/boxtype"):
 		f = open("/proc/boxtype",'r')
 		procmodel = f.readline().strip().lower()
@@ -256,6 +248,9 @@ def getAllInfo():
 				model = "Spark"
 		elif procmodel == "wetekplay":
 			brand = "WeTeK"
+			model = procmodel
+		elif procmodel == "osmini":
+			brand = "Edision"
 			model = procmodel
 	elif fileExists("/proc/stb/info/model"):
 		f = open("/proc/stb/info/model",'r')


### PR DESCRIPTION
This reverts commit 9f74ce1606c97a50215ea43aa8b89f0af0d52a89.

The latest drivers do not include vumodel proc entry any more.

```
root@osmini:~# cat /proc/stb/info/version
20160314
root@osmini:~# ls /proc/stb/info/
board_revision  boxtype         chipset         model           serial_number   subtype         version
```