### PR TITLE
Fix: show running events in multiepg even if older than 2 hours

### DIFF
--- a/plugin/controllers/models/services.py
+++ b/plugin/controllers/models/services.py
@@ -795,7 +795,9 @@ def getMultiEpg(self, ref, begintime=-1, endtime=None):
 				picons[channel] = getPicon(event[4])
 
 			slot = int((event[1]-offset) / 7200)
-			if slot > -1 and slot < 12 and event[1] < lastevent:
+			if slot < 0:
+				slot = 0
+			if slot < 12 and event[1] < lastevent:
 				ret[channel][slot].append(ev)
 
 	return { "events": ret, "result": True, "picons": picons }


### PR DESCRIPTION
The current code discards these events because they do not fit into any 2-hour-slot. As only running events can be older than current time for the epg search used, fix is simple: put them into the first slot.