### PR TITLE
Get rid of "fixedheadertable" Javascript to create a fixed header table.

### DIFF
--- a/plugin/controllers/views/ajax/event.tmpl
+++ b/plugin/controllers/views/ajax/event.tmpl
@@ -7,9 +7,6 @@
 #from Plugins.Extensions.OpenWebif.local import tstrings
 
 <style>
-table { font-size:12px; font-family: Verdana,Arial,sans-serif;}
-tr {background-color: #F0F7FC;}
-
 .ti_icon {
 margin:5px 2px 0px 0px;
 height:25px;

--- a/plugin/controllers/views/ajax/multiepg2.tmpl
+++ b/plugin/controllers/views/ajax/multiepg2.tmpl
@@ -13,7 +13,6 @@
 <script type="text/javascript" src="../js/jquery-1.6.2.min.js"></script>
 <script type="text/javascript" src="../js/jquery-ui-1.8.18.custom.min.js"></script>
 <script type="text/javascript" src="../js/openwebif-1.1.min.js"></script>
-<script type="text/javascript" src="../js/jquery.fixedheadertable.min.js"></script>
 <script type="text/javascript">initJsTranslation($dumps($tstrings))</script>
 
 <title>Open Webif $tstrings['multi_epg']</title>
@@ -24,8 +23,9 @@
 <style>
 body {background-image: none;background-color: #FFF; }
 #tvcontent {padding:0px;}
-table { font-family: Verdana; font-size: 11px; }
+table { font-family: Verdana; font-size: 12px; }
 tr { vertical-align: top }
+.float { float:left }
 .service { font-weight: bold; font-size: 12px; color:#fff; background-color: #1c47ae; line-height:30px; padding: 3px; white-space: nowrap; overflow: hidden; width: 184px}
 .service img { width:50px; height:30px; float:left; margin-right:10px; }
 .title { font-weight: bold; color: #061c37; }
@@ -36,42 +36,37 @@ tr { vertical-align: top }
 .event { cursor: pointer; width: 190px; overflow:hidden; }
 .bq { background-color: #1c478e; font-size: 11px; font-weight: bold; color: #fff; padding: 2px 4px; line-height: 18px; cursor: pointer; white-space: nowrap; display: inline-block; margin: 1px 1px; }
 .bq.selected { color: #A9D1FA; }
-.plus { background-color: #dfeffc; font-size: 13px; font-weight: bold; color: #1c478e; padding: 2px 4px; line-height: 21px; cursor: pointer; white-space: nowrap; }
+.plus { background-color: #dfeffc; font-size: 13px; font-weight: bold; color: #1c478e; padding: 2px 4px; margin: 1px; line-height: 21px; cursor: pointer; white-space: nowrap; }
 .plus.selected { color: #ea7409; }
 .timer { color: #f00; font-weight: bold; font-size: 10px; }
 .timer.disabled { color: #f80; }
 #eventdescription { width: 375px; height: auto; position: fixed; top: 205px; left: 350px; z-index: 1000; display: none; overflow: auto; }
 html, body, #tvcontent { width:100%; height:100%;}
-.fht-table,.fht-table thead,.fht-table tfoot,.fht-table tbody,.fht-table tr,.fht-table th,.fht-table td{font-size:100%;font:inherit;vertical-align:top;margin:0;padding:0}
-.fht-table{border-collapse:collapse;border-spacing:0}
-.fht-table-wrapper,.fht-table-wrapper .fht-thead,.fht-table-wrapper .fht-tfoot,.fht-table-wrapper .fht-fixed-column .fht-tbody,.fht-table-wrapper .fht-fixed-body .fht-tbody,.fht-table-wrapper .fht-tbody{overflow:hidden;position:relative}
-.fht-table-wrapper .fht-fixed-body .fht-tbody,.fht-table-wrapper .fht-tbody{overflow:auto}
-.fht-table-wrapper .fht-table .fht-cell{overflow:hidden;height:1px}
-.fht-table-wrapper .fht-fixed-column,.fht-table-wrapper .fht-fixed-body{top:0;left:0;position:absolute}
-.fht-table-wrapper .fht-fixed-column{z-index:1}
 #atdialog { width: 90%; height: auto; position: fixed; top: 10px; left: 10px; z-index: 1001; display: none; overflow: auto; }
-}
+
+thead tr, tfoot tr { display: block; width: 100%; }
+thead th, tfoot th { width: 200px; }
+tbody { width: 100%; height: 100%; overflow-y: auto; display: block; }
+.wrapper { overflow-x: auto; width: 100%; }
 </style>
 <div id="tvcontent">
-<table style="margin:0">
-<tr>
+<div>
 #for $slot in range(0,7)
-	<td class="plus #if $slot==$day then 'selected' else '' #" js:day="$(slot)">$tstrings[("day_" + (time.strftime("%w", time.localtime(time.time()+86400*slot))))]</td>
+<div class="float plus #if $slot==$day then 'selected' else '' #" js:day="$(slot)">$tstrings[("day_" + (time.strftime("%w", time.localtime(time.time()+86400*slot))))]</div>
 #end for
-</tr>
-</table>
+<br clear="all">
+</div>
 
-<table>
-<tr>
+<div style="height:25px;overflow:hidden">
 #for $bq in $bouquets
-<td class="bq #if $bq[0]==$bref then 'selected' else '' #" js:ref="$quote($bq[0])">$bq[1]</td>
+<div class="float bq #if $bq[0]==$bref then 'selected' else '' #" js:ref="$quote($bq[0])">$bq[1]</div>
 #end for
-</tr>
-</table>
+<br clear="all"/>
+</div>
 
 #set $renderEventBlock = $renderEvtBlock()
-<table cellpadding="0" cellspacing="0" id="TBL1">
-#block channelsInBouquet
+<div class="wrapper">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
 <thead>
 <tr>
 	#for $sname, $eventlist in $events.iteritems()
@@ -79,8 +74,7 @@ html, body, #tvcontent { width:100%; height:100%;}
 	#end for
 </tr>
 </thead>
-#end block
-<tbody>
+<tbody id="evttbl">
 	#set hasEvents = False
 	#for $slot in range(0,12)
 <tr class="$(slot%2 and 'odd' or 'even')">
@@ -95,7 +89,15 @@ html, body, #tvcontent { width:100%; height:100%;}
 </tr>
 	#end for
 </tbody>
+<tfoot>
+<tr>
+	#for $sname, $eventlist in $events.iteritems()
+	<th class="border"><div class="service"><img src="$(picons[$sname])" /> $sname</div></th>
+	#end for
+</tr>
+</tfoot>
 </table>
+</div>
 </div>
 <div id="eventdescription"></div>
 <div id="atdialog">
@@ -108,6 +110,8 @@ html, body, #tvcontent { width:100%; height:100%;}
 #end if
 
 <script>
+\$("#evttbl").height( (\$(window).height()-124) + "px");
+\$(window).resize(function(){ \$("#evttbl").height( (\$(window).height()-124) + "px"); });
 var picons = $dumps($picons);
 var reloadTimers = false;
 \$(".bq").click(function() {
@@ -127,14 +131,6 @@ var reloadTimers = false;
 	\$("#tvcontent").html(loadspinner).load('../ajax/multiepg2?reloadtimer=0&bref=${quote($bref)}&day='+day);
 });
 \$('#editTimerForm').load('../ajax/edittimer');
-
-\$('#TBL1').fixedHeaderTable({ 
-	footer: true,
-	cloneHeadToFoot: true,
-	altClass: 'odd',
-	autoShow: true
-});
-
 </script>
 </body>
 </html>


### PR DESCRIPTION
This patch removes the fixedheadertable Javascript from multiepg2.tmpl. Fixedheadertable always placed the footer below visible content, and scrolling behaviour under Android is, well, not optimal.

I've tested the patch with Chrome and Firefox on my Macbook and Chrome on my Android tablet. Unfortunately I don't have a Windows PC at my hands, so I can't tell if it works correctly with IE as well.

Please consider merging.

Cheers, Robert.