### PR TITLE
Fix double scrollbars in multiepg views

### DIFF
--- a/plugin/controllers/views/ajax/multiepg.tmpl
+++ b/plugin/controllers/views/ajax/multiepg.tmpl
@@ -77,8 +77,6 @@
 <script>
 var picons = $dumps($picons);
 var reloadTimers = false;
-\$("#tbl1body").height( (\$("#tvcontent").height()-\$("#navepg").height()-72) + "px");
-\$(window).resize(function(){ \$("#tbl1body").height( (\$("#tvcontent").height()-\$("#navepg").height()-72) + "px"); });
 \$(".bq").click(function() {
 	var id = \$(this).attr("js:ref");
 	\$("#tvcontent").html(loadspinner).load('ajax/multiepg?bref='+id);

--- a/plugin/controllers/views/ajax/multiepg2.tmpl
+++ b/plugin/controllers/views/ajax/multiepg2.tmpl
@@ -107,8 +107,6 @@ tbody { width: 100%; height: 100%; overflow-y: auto; display: block; }
 #end if
 
 <script>
-\$("#tbl1body").height( (\$(window).height()-124) + "px");
-\$(window).resize(function(){ \$("#tbl1body").height( (\$(window).height()-124) + "px"); });
 var picons = $dumps($picons);
 var reloadTimers = false;
 \$(".bq").click(function() {


### PR DESCRIPTION
When showing multiepg views, the contents are often presented
in a view that has scrollbars for the EPG table, but this view
is subsequently embedded in another view with scrollbars. This
results in double scrollbars and a user interface that is very
difficult to navigate.

There is actually no need to specify an explicit height for the
table body. Removing this height gets rid of the inner scrollbar
and as a result the view only ends up with the outer scrollbar.


Signed-off-by: Peter Urbanec <git.user@urbanec.net>