### PR TITLE
Readd functionality to _only_ scroll the inner table of multi EPG. 

### DIFF
--- a/plugin/controllers/views/ajax/multiepg.tmpl
+++ b/plugin/controllers/views/ajax/multiepg.tmpl
@@ -24,6 +24,7 @@
 	#tbl1 thead tr, #tbl1 tfoot tr { display: block; width: 100%; }
 	#tbl1 tbody { width: 100%; height: 100%; overflow-y: auto; display: block; }
 	.wrapper { overflow-x: auto; width: 100%; }
+	td.border { width: 190px; }
 </style>
 
 <div id="navepg">
@@ -77,6 +78,22 @@
 <script>
 var picons = $dumps($picons);
 var reloadTimers = false;
+function getScrollBarWidth () {
+    var \$outer = \$('<div>').css({visibility: 'hidden', width: 100, overflow: 'scroll'}).appendTo('body'),
+        widthWithScroll = \$('<div>').css({width: '100%'}).appendTo(\$outer).outerWidth();
+    \$outer.remove();
+    return 100 - widthWithScroll;
+}
+var scrollBarWidth=getScrollBarWidth();
+function fixTableHeight() {
+    var addScrollBarWidth = scrollBarWidth;
+    if (\$('#tbl1').width() <= \$("#tvcontent").width()){
+        addScrollBarWidth = 0;
+    }
+    \$("#tbl1body").height( (\$("#tvcontent").height() - \$("#navepg").height() - 2*\$("#tbl1 thead").height() - addScrollBarWidth - 2) + "px");
+}
+fixTableHeight();
+\$(window).resize(function(){ fixTableHeight(); });
 \$(".bq").click(function() {
 	var id = \$(this).attr("js:ref");
 	\$("#tvcontent").html(loadspinner).load('ajax/multiepg?bref='+id);

--- a/plugin/controllers/views/ajax/multiepg2.tmpl
+++ b/plugin/controllers/views/ajax/multiepg2.tmpl
@@ -47,6 +47,7 @@ html, body, #tvcontent { width:100%; height:100%;}
 thead tr, tfoot tr { display: block; width: 100%; }
 tbody { width: 100%; height: 100%; overflow-y: auto; display: block; }
 .wrapper { overflow-x: auto; width: 100%; }
+td.border { width: 190px; }
 </style>
 <div id="tvcontent">
 
@@ -107,6 +108,22 @@ tbody { width: 100%; height: 100%; overflow-y: auto; display: block; }
 #end if
 
 <script>
+function getScrollBarWidth () {
+    var \$outer = \$('<div>').css({visibility: 'hidden', width: 100, overflow: 'scroll'}).appendTo('body'),
+        widthWithScroll = \$('<div>').css({width: '100%'}).appendTo(\$outer).outerWidth();
+    \$outer.remove();
+    return 100 - widthWithScroll;
+}
+var scrollBarWidth=getScrollBarWidth();
+function fixTableHeight() {
+    var addScrollBarWidth = scrollBarWidth;
+    if (\$('#tbl1').width() <= \$(window).width()){
+        addScrollBarWidth = 0;
+    }
+    \$("#tbl1body").height( (\$(window).height() - \$("#navepg").height() - 2*\$("thead").height() - addScrollBarWidth - 2) + "px");
+}
+fixTableHeight();
+\$(window).resize(function(){ fixTableHeight(); });
 var picons = $dumps($picons);
 var reloadTimers = false;
 \$(".bq").click(function() {


### PR DESCRIPTION
This time taking scrollbar width under Windows as well as height of other non table content into account. Also installing a resize event handler.

Tested with Windows 7/Chrome, Mac OS X/Chrome, Android 5/Chrome.

Please consider merging.

Cheers,
Robert.