### PR TITLE
Fix blue screen when you stream via RemoteStreamConvert

### DIFF
--- a/plugin/controllers/stream.py
+++ b/plugin/controllers/stream.py
@@ -50,8 +50,12 @@ class StreamAdapter:
 	def requestWrite(self, notused1 = None, notused2 = None):
 		converter_args = []
 		self.converter = Streaming(converter_args)
-		self.converter.source = self
-		self.request.write(self.converter.getText())
+		if self.converter:
+			try:
+				self.converter.source = self
+				self.request.write(self.converter.getText())
+			except:
+				return
 
 class StreamController(resource.Resource):
 	def __init__(self, session, path = ""):


### PR DESCRIPTION
This corrects the BSOD that occurs in the host server from a client to zap receiver using the plugin RemoteStreamConvert