### PR TITLE
Add basic Dreambox OS support

### DIFF
--- a/plugin/controllers/models/grab.py
+++ b/plugin/controllers/models/grab.py
@@ -11,16 +11,21 @@
 from enigma import eConsoleAppContainer
 from twisted.web import static, resource, http, server
 import os
+from Plugins.Extensions.OpenWebif.controllers.models.info import getInfo
 
 GRAB_PATH = '/usr/bin/grab'
+DREAMOS = getInfo()['oever'] == "OE 2.2"
 
 class grabScreenshot(resource.Resource):
 	def __init__(self,session, path = ""):
 		resource.Resource.__init__(self)
 		self.session = session
 		self.container = eConsoleAppContainer()
-		self.container.appClosed.append(self.grabFinished)
-		# self.container.dataAvail.append(self.grabData)
+		if DREAMOS:
+			self.container.appClosed_conn= self.container.dataAvail.connect(self.grabFinished)
+		else:
+			self.container.appClosed.append(self.grabFinished)
+			# self.container.dataAvail.append(self.grabData)
 
 	def render(self, request):
 		self.request = request

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -71,6 +71,7 @@ config.OpenWebif.epg_encoding = ConfigSelection(default = 'utf-8', choices = [ '
 										'iso-8859-10',
 										'iso-8859-16'])
 imagedistro = getInfo()['imagedistro']
+DREAMOS = getInfo()['oever'] == "OE 2.2"
 
 class OpenWebifConfig(Screen, ConfigListScreen):
 	skin = """
@@ -177,6 +178,8 @@ def IfUpIfDown(reason, **kwargs):
 def startSession(reason, session):
 	global global_session
 	global_session = session
+	if DREAMOS: # it seems that DreamOS deactivated WHERE_NETWORKCONFIG_READ
+		HttpdStart(global_session)
 
 def main_menu(menuid, **kwargs):
 	if menuid == "network":


### PR DESCRIPTION
The Dreambox OS has a few changes in the enigma2 API. This will apply the neccesary patches so that the OpenWebif will work there, too.

The main differences are:
- Changes in the enigma2 API for containers (`connect` instead of `append`)
- New Components for Network and Network
- `PluginDescriptor.WHERE_NETWORKCONFIG_READ` didn't seem to be working

A few minor things are still missing:
- [ ] Add .deb packaging script
- [ ] "Box Info": show all IPv6 information
- [ ] "Box Info": Detect real hard disk size
- [ ] Identify chipset, distro, driver date, kernel version and pictures of DreamOS boxes
- [ ] Transcoding
- [ ] Maybe add new DreamOS screenshot function instead of grab
- [ ] Maybe other instances of `e*Container()` that need to be changed?

Everything is tested with the latest DMM unstable on DM7080HD. It shouldn't break anything on other boxes
