### PR TITLE
Fix issue #377

### DIFF
--- a/plugin/controllers/views/ajax/bqe.tmpl
+++ b/plugin/controllers/views/ajax/bqe.tmpl
@@ -14,6 +14,8 @@
 	.selectable .ui-selected { background: #F39814; color: white; }
 	.selectable { list-style-type: none; margin: 0; padding: 0; width: 100%; }
 	.selectable li { margin: 1px; padding: 0.1em; font-size: 1em; height: 20px; cursor: pointer; }
+
+	.marker { float: right; opacity: 0.5; color: #00c; font-size: 80%; }
 </style>
 <div id="content_container">
 <div id="content_main" style="min-height: 500px;">

--- a/plugin/controllers/views/ajax/bqe.tmpl
+++ b/plugin/controllers/views/ajax/bqe.tmpl
@@ -13,107 +13,109 @@
 	.selectable .ui-selecting { background: #FECA40; }
 	.selectable .ui-selected { background: #F39814; color: white; }
 	.selectable { list-style-type: none; margin: 0; padding: 0; width: 100%; }
-	.selectable li { margin: 1px; padding: 0.1em; font-size: 1em; height: 20px; }
+	.selectable li { margin: 1px; padding: 0.1em; font-size: 1em; height: 20px; cursor: pointer; }
 </style>
+<div id="content_container">
 <div id="content_main" style="min-height: 500px;">
 <div id="info">
+
 <h3>$tstrings['Bouquet_Editor']</h3>
-<div style="background-color: #EEE">
-<div style="display: inline-block; width: 100%; zoom: 1;">
+<div style="background-color: #eee; display: inline-block; width: 100%; zoom: 1;">
 
 <div style="width:50%; height:50%; float:left">
 <div style="padding:5px;">
 
+<!-- TODO: change to class -->
 <div id="toolbar-header">
-<span id="toolbar"><span id="tb1">
-<input type="radio" id="btn0" name="tb1" checked="checked" /><label for="btn0">$tstrings['tv']</label>
-<input type="radio" id="btn1" name="tb1"/><label for="btn1">$tstrings['radio']</label>
-</span></span>
+    <span id="tb1">
+        <input type="radio" id="toolbar-choose-tv" name="tb1" checked="checked" /><label for="toolbar-choose-tv">$tstrings['tv']</label>
+        <input type="radio" id="toolbar-choose-radio" name="tb1"/><label for="toolbar-choose-radio">$tstrings['radio']</label>
+    </span>
 </div>
 
 <div id="toolbar-header">
-<span id="toolbar"><span id="tb2">
-<input type="radio" id="btn2" name="tb2" /><label for="btn2">$tstrings['satellites']</label>
-<input type="radio" id="btn3" name="tb2" checked="checked" /><label for="btn3">$tstrings['providers']</label>
-<input type="radio" id="btn4" name="tb2" /><label for="btn4">$tstrings['all_channels']</label>
-</span></span>
+    <span id="tb2">
+        <input type="radio" id="toolbar-choose-satellites" name="tb2" /><label for="toolbar-choose-satellites">$tstrings['satellites']</label>
+        <input type="radio" id="toolbar-choose-providers" name="tb2" checked="checked" /><label for="toolbar-choose-providers">$tstrings['providers']</label>
+        <input type="radio" id="toolbar-choose-channels" name="tb2" /><label for="toolbar-choose-channels">$tstrings['all_channels']</label>
+    </span>
 </div>
-	<div id="sel0" style="height: 200px;overflow-y:scroll;">
-	<ol id="provider" class="selectable" >
-	</ol>
-	</div>
-	<div style="margin:5px 0 5px 0;">
-		<button id='btnaddp' onclick="addprovider(); return false;">$tstrings['bqe_add_provider_as_bouquet']</button>
-	</div>
-	<div>
-	<div style="margin:5px 0 5px 0;">
-	$tstrings['bqe_search'] :<input id="searchch" value="...">
-	</div>
-	</div>
 
-	<div id="sel1" style="height: 300px;overflow-y:scroll;">
-	<ol id="channels" class="selectable" >
-	</ol>
-	</div>
+<div id="sel0" style="height: 200px;overflow-y:scroll;">
+	<ol id="provider" class="selectable"></ol>
+</div>
+
+<div style="margin:5px 0 5px 0;">
+	<button id="btn-provider-add">$tstrings['bqe_add_provider_as_bouquet']</button>
+</div>
+
+<div style="margin:5px 0 5px 0;">
+	$tstrings['bqe_search']: <input id="searchch" value="...">
+</div>
+
+<div id="sel1" style="height: 300px;overflow-y:scroll;">
+	<ol id="channels" class="selectable"></ol>
+</div>
 	
-	<div style="margin:5px 0 5px 0;">
-		<button id='btnaddc' onclick="addchannel(); return false;">$tstrings['bqe_add_channel']</button>
-		<button id='btnadda' onclick="addalter(); return false;">$tstrings['bqe_add_alternative']</button>
-	</div>
+<div style="margin:5px 0 5px 0;">
+	<button id="btn-channel-add">$tstrings['bqe_add_channel']</button>
+	<button id="btn-alternative-add">$tstrings['bqe_add_alternative']</button>
+</div>
 
-</div></div>
+</div>
+</div>
 
 <div style="width:50%; height:50%; float:right">
 <div style="padding:5px;">
+
 <div id="toolbar-header">
-<span id="toolbar"><span id="tb3">
-<button id="btn5">$tstrings['bqe_reload']</button>
-<button id="btn6">$tstrings['bqe_export']</button>
-<button id="btn7">$tstrings['bqe_import']</button>
-</span></span>
+	<span id="tb3">
+		<button id="toolbar-bouquets-reload">$tstrings['bqe_reload']</button>
+		<button id="toolbar-bouquets-export">$tstrings['bqe_export']</button>
+		<button id="toolbar-bouquets-import">$tstrings['bqe_import']</button>
+	</span>
 </div>
-	<div style="padding:5px;">
+
+<div style="padding:5px;">
 	<div id="sel2" style="height: 280px;overflow-y:scroll;">
-	<ol id="bql" class="selectable" >
-	</ol>
+		<ol id="bql" class="selectable"></ol>
 	</div>
 	<div style="margin:5px 0 5px 0;">
-		<button id='btnbadd' onclick="addbq(); return false;">$tstrings['bqe_add_bq']</button>
-		<button id='btnbren' onclick="renbq(); return false;">$tstrings['bqe_rename_bq']</button>
-		<button id='btnbdel' onclick="delbq(); return false;">$tstrings['bqe_delete_bq']</button>
+		<button id="btn-bouquet-add">$tstrings['bqe_add_bq']</button>
+		<button id="btn-bouquet-rename">$tstrings['bqe_rename_bq']</button>
+		<button id="btn-bouquet-delete">$tstrings['bqe_delete_bq']</button>
 	</div>
 	
 	<div id="sel3" style="height: 300px;overflow-y:scroll;">
-	<ol id="bqs" class="selectable" >
-	</ol>
+		<ol id="bqs" class="selectable"></ol>
 	</div>
 	<div style="margin:5px 0 5px 0;">
-		<button id='btncdel' onclick="delc(); return false;">$tstrings['bqe_delete_channel']</button>
-		<button id='btnmadd' onclick="addm(); return false;">$tstrings['bqe_add_marker']</button>
-		<button id='btnmgren' onclick="renmg(); return false;">$tstrings['bqe_rename']</button>
+		<button id="btn-channel-delete">$tstrings['bqe_delete_channel']</button>
+		<button id="btn-marker-add">$tstrings['bqe_add_marker']</button>
+		<button id="btn-marker-group-rename">$tstrings['bqe_rename']</button>
 	</div>
 	
-	</div>
 </div>
 
 </div>
 </div>
-<div id="errorbox" class="timerlist_row" style="color: red;">
+
+<br clear="all">
+<div id="errorbox" class="timerlist_row" style="color:red; display:none">
 	<div class="ui-state-error ui-corner-all" style="padding: 0 .7em;"> 
-	<p><span class="ui-icon ui-icon-alert" style="float: left; margin-right: .3em;"></span> 
-		<span id="error"></span>
-		<span id="success" style="color: green;"></span>
+		<p>
+			<span class="ui-icon ui-icon-alert" style="float: left; margin-right: .3em;"></span> 
+			<span id="error"></span>
+			<span id="success" style="color: green;"></span>
+		</p>
 	</div>
 </div>
 
-</div></div></div>
-<form id="uploadrestore" style="display:none" action"uploadrestore" method="post" enctype="multipart/form-data" encoding="multipart/form-data" >
+</div></div>
+<form id="uploadrestore" style="display:none" action"uploadrestore"="" method="post" enctype="multipart/form-data" encoding="multipart/form-data">
 <input type="file" name="rfile" id="rfile">
 </form>
-<script type="text/javascript" src="js/bqe-1.1.min.js"></script>
-<script type="text/javascript">
-#raw
-$(function() { InitPage();});
-#end raw
-</script>
+
+</div>
+<script src="js/bqe.js"></script>
 #end filter

--- a/plugin/public/js/bqe.js
+++ b/plugin/public/js/bqe.js
@@ -1,752 +1,693 @@
 //******************************************************************************
 //* bqe.js: openwebif Bouqueteditor plugin
-//* Version 1.1
+//* Version 2.0
 //******************************************************************************
 //* Copyright (C) 2014-2016 Joerg Bleyel
 //* Copyright (C) 2014-2016 E2OpenPlugins
 //*
 //* Authors: Joerg Bleyel <jbleyel # gmx.net>
+//*          Robert Damas <https://github.com/rdamas>
 //* License GPL V2
 //* https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/blob/master/LICENSE.txt
 //*******************************************************************************
 // TODO: alternatives
 
-var Mode=0;
-var cType=1;
-var currentBQ=null;
-var currentProv=null;
+(function() {
 
-var srccl=[];
-var dstbl=[];
-var dstcl=[];
-var seldstbl=[];
-var seldstcl=[];
-var selsrccl=[];
-var markerstr = "<span style='float:right'>(M)</span>";
-var rootreqstr = "/bouqueteditor/api/";
-
-function buildRefStr(type)
-{
-	var r = (Mode===0) ? '1:7:1:0:0:0:0:0:0:0:(type == 1) || (type == 17) || (type == 195) || (type == 25) || (type == 22) ' : '1:7:2:0:0:0:0:0:0:0:(type == 2) ';
-	if(type===0) {
-		r+='FROM BOUQUET "bouquets.';
-		r+=(Mode===0) ? 'tv' : 'radio';
-		r+='" ORDER BY bouquet';
-	}
-	if(type===1)
-		r+='FROM PROVIDERS ORDER BY name';
-	if(type===2)
-		r+='FROM SATELLITES ORDER BY satellitePosition';
-	if(type===3)
-		r+='ORDER BY name';
-
-	console.log(r);
-	return encodeURIComponent(r);
-}
-
-function BQELoadTVR(nmode)
-{
-	var rl=false;
-	if(nmode!==Mode || nmode===3) {
-		rl=true;
-	}
-	
-	if(nmode>1) {
-		Mode=0;
-		rl=true;
-	}
-	else
-		Mode=nmode;
-	
-	if(cType===0)
-		BQELoadSatellites();
-	if(cType===1)
-		BQELoadProvider();
-	if(cType===2)
-		BQELoadAll();
-
-	if(rl) 
-		BQELoadBQ();
-}
-
-function BQELoadSatellites()
-{
-	cType = 0;
-	$("#sel0").show();
-	$("#channels").empty();
-	srccl=[];
-	selsrccl=[];
-	SetCHButtons();
-
-	var ref = buildRefStr(2);
-	var options = "";
-
-	$.getJSON( "/api/getsatellites?sRef=" + ref, function( data ) {
-		var s = data['satellites'];
-		$.each( s, function( key, val ) {
-			var sref = val['service'];
-			var name = val['name'];
-			options += "<li class='ui-widget-content' id='"+encodeURIComponent(sref)+"'>"+name+"</li>";
-		});
-		$("#provider").empty();
-		$("#provider").append( options);
-		$("#provider").selectable().children().first().addClass('ui-selected');
-		var id = $("#provider").selectable().children().first().attr('id');
-		changeProvider(id);
-	});
-	
-
-}
-function BQELoadProvider()
-{
-	cType = 1;
-	$("#sel0").show();
-	$("#channels").empty();
-	srccl=[];
-	selsrccl=[];
-	SetCHButtons();
-
-	var ref = buildRefStr(1);
-	var options = "";
-
-	$.getJSON( "/api/getservices?sRef=" + ref, function( data ) {
-		var s = data['services'];
-		$.each( s, function( key, val ) {
-			var sref = val['servicereference']
-			var name = val['servicename']
-			options += "<li class='ui-widget-content' id='"+encodeURIComponent(sref)+"'>"+name+"</li>";
-		});
-		$("#provider").empty();
-		$("#provider").append( options);
-		$("#provider").selectable().children().first().addClass('ui-selected');
-		var id = $("#provider").selectable().children().first().attr('id');
-		changeProvider(id);
-	});
-
-}
-
-function BQELoadBQ()
-{
-
-	var ref = buildRefStr(0);
-	var options = "";
-
-	dstbl=[];
-	seldstbl=[];
-	SetBQButtons();
-	
-	$.getJSON( rootreqstr + "getservices?sRef=" + ref, function( data ) {
-		var s = data['services'];
-		var idx=0;
-		$.each( s, function( key, val ) {
-			dstbl.push(val); 
-			var name = val['servicename'];
-			options += "<li class='ui-widget-content' id='"+idx+"'><div class='handle'><span class='ui-icon ui-icon-carat-2-n-s'></span></div>"+name+"</li>";
-			idx++;
-		});
-		$("#bql").empty();
-		$("#bql").append( options);
-		$("#bql").selectable().children().first().addClass('ui-selected');
-		var id = $("#bql").selectable().children().first().attr('id');
-		SetBQButtons();
-		changeBQidx(id);
-	});
-}
-
-function BQELoadAll()
-{
-	$('#btnaddp').prop( "disabled",true );
-	$("#sel0").hide();
-	cType = 2
-	var ref = buildRefStr(3);
-	var options = "";
-	srccl=[];
-	selsrccl=[];
-	SetCHButtons();
-
-	$.getJSON( "/api/getservices?sRef=" + ref, function( data ) {
-		var s = data['services'];
-		$.each( s, function( key, val ) {
-			var name = val['servicename']
-			options += "<li class='ui-widget-content'>"+name+"</li>";
-			srccl.push(val); 
-		});
-		$("#channels").empty();
-		$("#channels").append( options);
-	});
-
-}
-
-function changeBQidx(idx)
-{
-	var i = parseInt(idx);
-	var bref = dstbl[i].servicereference;
-	changeBQ(bref);
-}
-
-function changeBQ(bref)
-{
-	var options = "";
-	currentBQ=bref;
-	dstcl=[];
-	seldstcl=[];
-
-	$.getJSON( rootreqstr + "getservices?sRef=" + encodeURIComponent(bref), function( data ) {
-		var s = data['services'];
-		currentCH=null;
-		var idx=0;
-		$.each( s, function( key, val ) {
-			dstcl.push(val); 
-			var name = val['servicename']
-			var m = (val['ismarker'] === '1') ? markerstr : "";
-			options += "<li class='ui-widget-content' id='"+idx+"'><div class='handle'><span class='ui-icon ui-icon-carat-2-n-s'></span></div>"+name+m+"</li>";
-			idx++;
-		});
-		$("#bqs").empty();
-		if (idx>0) {
-			$("#bqs").append( options);
-			$("#bqs").selectable().children().first().addClass('ui-selected');
-			var id = $("#bqs").selectable().children().first().attr('id');
-			seldstcl.push(id);
-		}
-		SetDestCHButtons();
-	});
-
-}
-
-function changeCH(obj)
-{
-	currentCH = obj.value;
-}
-
-function changeProvider(sref)
-{
-	$('#btnaddp').prop( "disabled", (cType!==1) );
-	currentProv = sref;
-	var options = "";
-	srccl=[];
-	selsrccl=[];
-	SetCHButtons();
-
-	$.getJSON( "/api/getservices?sRef=" + sref, function( data ) {
-		var s = data['services'];
-		$.each( s, function( key, val ) {
-			var name = val['servicename']
-			options += "<li class='ui-widget-content'>"+name+"</li>";
-			srccl.push(val); 
-		});
-		$("#channels").empty();
-		$("#channels").append( options);
-	});
-
-}
-
-function searchChannel(txt)
-{
-	var t = txt.toLowerCase();
-	$( "#channels li").each(function(){
-		if($(this).html().toLowerCase().indexOf(t) !== -1)
-			$(this).show();
-		else
-			$(this).hide();
-	});
-	
-	$('#channels .ui-selected').removeClass('ui-selected');
-	selsrccl=[];
-	SetCHButtons();
-}
-
-
-function addprovider()
-{
-	$.getJSON( rootreqstr + "addprovidertobouquetlist?sProviderRef=" + currentProv + '&mode=' + Mode, function( data ) {
-		var r = data.Result;
-		if(r[0])
-			showError(r[1],r[0]);
-		BQELoadBQ();
-	});
-}
-
-function addchannel()
-{
-	var srefs = [];
-	$.each( selsrccl, function( key, val ) {
-		var idx = parseInt(val);
-		srefs.push(srccl[idx].servicereference);
-	});
-
-	var reqjobs = [];
-	var dstref = "";
-	
-	if (seldstcl.length>0) {
-		var si = seldstcl[0];
-		var i = parseInt(si);
-		dstref = dstcl[i].servicereference;
-	}
-	
-	$.each( srefs, function( key, val ) {
-		reqjobs.push($.getJSON( rootreqstr + "addservicetobouquet?sBouquetRef=" + encodeURIComponent(currentBQ) + "&sRef=" + encodeURIComponent(val) + '&sRefBefore=' + encodeURIComponent(dstref), function() {}));
-	});
-
-	if(reqjobs.length !== 0) {
-		$.when.apply($, reqjobs).then(function() {
-			changeBQ(currentBQ);
-		});
-	}
-
-}
-
-function addalter()
-{
-	NOTI();
-	return;
-	var sref = obj.value;
-	var options = "";
-
-	$.getJSON( rootreqstr + "addservicetoalternative?sBouquetRef=" + encodeURIComponent(currentBQ) + "&sCurrentRef=" + encodeURIComponent(currentCH) + "&sRef=" + encodeURIComponent(sref) + "&mode=" + Mode, function( data ) {
-		// check result
-	});
-
-}
-
-function movec(arr)
-{
-	var cmd = [];
-	var m=false;
-	
-	if((arr.length === 0) || (arr.length !== dstcl.length))
-		return;
-
-	for (var i=0;i<arr.length;i++)
-	{
-		var pos = parseInt(arr[i]);
-		if(m && i>pos)
-			break;
-		if(i!==pos)
-		{
-			cmd.push( encodeURIComponent(dstcl[pos].servicereference) + "&mode=" + Mode + "&position=" + i);
-			m=true;
-		}
-	}
-
-	var reqjobs = [];
-	$.each( cmd, function( key, val ) {
-		reqjobs.push($.getJSON(rootreqstr + "moveservice?sBouquetRef=" + encodeURIComponent(currentBQ) + "&sRef=" + val , function() {}));
-	});
-
-	if(reqjobs.length !== 0) {
-		$.when.apply($, reqjobs).then(function() {
-			changeBQ(currentBQ);
-		});
-	}
-
-}
-
-function movebq(arr)
-{
-	var cmd = [];
-	var m=false;
-	
-	if((arr.length === 0) || (arr.length !== dstbl.length))
-		return;
-
-	for (var i=0;i<arr.length;i++)
-	{
-		var pos = parseInt(arr[i]);
-		if(m && i>pos)
-			break;
-		if(i!==pos)
-		{
-			cmd.push( encodeURIComponent(dstbl[pos].servicereference) + "&mode=" + Mode + "&position=" + i);
-			m=true;
-		}
-	}
-
-	var reqjobs = [];
-	$.each( cmd, function( key, val ) {
-		reqjobs.push($.getJSON(rootreqstr + "movebouquet?sBouquetRef=" + val , function() {}));
-	});
-
-	if(reqjobs.length !== 0) {
-		$.when.apply($, reqjobs).then(function() {
-			BQELoadBQ();
-		});
-	}
-
-}
-
-function delc()
-{
-	if(seldstcl.length<1)
-		return;
-	var snames = [];
-	var srefs = [];
-	$.each( seldstcl, function( key, val ) {
-		var idx = parseInt(val);
-		snames.push(dstcl[idx].servicename);
-		srefs.push(dstcl[idx].servicereference);
-	});
-	var snamesstr = snames.join();
-	if(confirm(tstr_bqe_del_channel_question + "\n" + snamesstr + " ?") === false)
-		return;
-
-	var reqjobs = [];
-	$.each( srefs, function( key, val ) {
-		reqjobs.push($.getJSON(rootreqstr + "removeservice?sBouquetRef=" + encodeURIComponent(currentBQ) + "&sRef=" + encodeURIComponent(val) + "&mode=" + Mode, function() {}));
-	});
-
-	if(reqjobs.length !== 0) {
-		$.when.apply($, reqjobs).then(function() {
-			changeBQ(currentBQ);
-		});
-	}
-
-}
-
-function delbq()
-{
-	if(seldstbl.length!==1)
-		return;
-
-	var pos=parseInt(seldstbl[0]);
-	var sname = dstbl[pos].servicename;
-	var sref = dstbl[pos].servicereference
-
-	if(confirm(tstr_bqe_del_bouquet_question + "\n" + sname + " ?") === false)
-		return;
-
-	$.getJSON(rootreqstr + "removebouquet?sBouquetRef=" + encodeURIComponent(sref) + "&mode=" + Mode, function( data ) {
-		var r = data.Result;
-		if(r[0])
-			showError(r[1],r[0]);
-		BQELoadBQ();
-	});
-
-}
-
-function addbq()
-{
-	var newname=prompt(tstr_bqe_name_bouquet + ":");
-	if (newname.length){
-		$.getJSON(rootreqstr + "addbouquet?name=" + encodeURIComponent(newname) + "&mode=" + Mode , function( data ) {
-			var r = data.Result;
-			if(r[0])
-				showError(r[1],r[0]);
-			BQELoadBQ();
-		});
-	}
-}
-
-function addm()
-{
-	var newname=prompt(tstr_bqe_name_marker + ":");
-	if (newname.length){
-	
-		var dstref = "";
+	var BQE = function () {
+		// keep reference to object.
+		var self;
 		
-		if (seldstcl.length>0) {
-			var si = seldstcl[0];
-			var i = parseInt(si);
-			dstref = dstcl[i].servicereference;
-		}
+		// Mode=0: TV, Mode=1: Radio
+		var	Mode;
 		
-		$.getJSON(rootreqstr + "addmarkertobouquet?sBouquetRef=" + encodeURIComponent(currentBQ) + '&Name=' + encodeURIComponent(newname) +'&sRefBefore=' + encodeURIComponent(dstref) , function( data ) {
-			var r = data.Result;
-			if(r[0])
-				showError(r[1],r[0]);
-			changeBQ(currentBQ);
-		});
-	}
-}
+		// keep track of which list in left pane is shown.
+		// 0: satellites, 1: providers, 2: all channels
+		var cType;
 
-
-function renbq()
-{
-	if(seldstbl.length!==1)
-		return;
-	var pos=parseInt(seldstbl[0]);
-	var sname = dstbl[pos].servicename;
-	var sref = dstbl[pos].servicereference;
-	var newname=prompt(tstr_bqe_rename_bouquet + ':', sname);
-	if (newname && newname!=sname){
-		$.getJSON(rootreqstr + "renameservice?sRef=" + encodeURIComponent(sref) + "&mode=" + Mode + "&newName=" + encodeURIComponent(newname), function( data ) {
-			var r = data.Result;
-			if(r[0])
-				showError(r[1],r[0]);
-			BQELoadBQ();
-		});
-	}
-}
-
-function renmg()
-{
-	// rename marker or group
-	if(seldstcl.length!==1)
-		return;
-
-	var pos=parseInt(seldstcl[0]);
-
-	// TODO : rename group
-	if(dstcl[pos].ismarker === "0")
-		return;
-	
-	var sname = dstcl[pos].servicename;
-	var sref = dstcl[pos].servicereference;
-	var newname=prompt(tstr_bqe_rename_marker + ':', sname);
-	if (newname && newname!=sname){
-
-		var dstref = "";
-		pos++;
-		if(pos < dstcl.length) {
-			dstref = dstcl[pos].servicereference;
-		}
-		
-		$.getJSON(rootreqstr + "renameservice?sBouquetRef=" + encodeURIComponent(currentBQ) + "&sRef=" + encodeURIComponent(sref) + "&newName=" + encodeURIComponent(newname) + "&sRefBefore=" + encodeURIComponent(dstref), function( data ) {
-			var r = data.Result;
-			if(r[0])
-				showError(r[1],r[0]);
-			changeBQ(currentBQ);
-		});
-	}
-
-	
-}
-
-function SetDestCHButtons() {
-	var e = (seldstcl.length > 0)
-	$('#btncdel').prop( "disabled", !e );
-	$('#btnmadd').prop( "disabled", !e );
-
-	e = (seldstcl.length === 1)
-	if(e) {
-		var idx = seldstcl[0];
-		var i = parseInt(idx);
-		e = (dstcl[i].ismarker === "1");
-	}
-	$('#btnmgren').prop( "disabled", !e );
-
-}
-
-function SetCHButtons() {
-	var e = (selsrccl.length > 0)
-	$('#btnaddc').prop( "disabled", !e );
-	$('#btnadda').prop( "disabled", !e );
-}
-
-function SetBQButtons() {
-	var e = (seldstbl.length === 1)
-	$('#btnbren').prop( "disabled", !e );
-	$('#btnbdel').prop( "disabled", !e );
-}
-
-function NOTI()
-{
-	alert("NOT implemented YET");
-}
-
-function BQEBackup()
-{
-	var fn=prompt(tstr_bqe_filename + ':', 'bouquets_backup');
-	if (fn) {
-		$.getJSON(rootreqstr + 'backup?Filename='+fn, function( data ) {
-			var r = data.Result;
-			if(r[0]===false)
-				showError(r[1],r[0]);
-			else {
-				var url =  "/bouqueteditor/tmp/" + r[1];
-				window.open(url,'Download');
-			}
-		});
-	}
-}
-
-function BQEDoRestore(fn)
-{
-	if (fn) {
-		$.getJSON(rootreqstr + 'restore?Filename='+fn, function( data ) {
-			console.log(data);
-			var r = data.Result;
-			showError(r[1],r[0]);
-		});
-	}
-}
-
-
-function BQERestore()
-{
-	$("#rfile").trigger('click');
-}
-
-function prepareRestore(obj){
-	var fn = obj.val()
-	fn = fn.replace('C:\\fakepath\\','');
-	if(confirm(tstr_bqe_restore_question + " ( " + fn + ") ?") === false)
-		return;
-	
-	$('form#uploadrestore').unbind('submit');
-	$('form#uploadrestore').submit(function(e)
-	{
-		var formData = new FormData(this);
-		$.ajax({
-			url: '/bouqueteditor/uploadrestore',
-			type: 'POST',
-			data:  formData,
-			mimeType:"multipart/form-data",
-			contentType: false,
-			cache: false,
-			processData:false,
-			dataType: "json",
-			success: function(data, textStatus, jqXHR)
-			{
-				var r = data.Result;
-				if(r[0])
-					BQEDoRestore(r[1]);
-				else
-					showError("Upload File: " + textStatus);
+		return {
+			// Callback for display left panel providers list
+			// Triggers fetching and displaying dependent services list
+			// for selected provider
+			showProviders: function (options) {
+				$('#sel0').show();
+				$('#btn-provider-add')
+					.show()
+					.prop( 'disabled', (self.cType !==1 ) );
+				$('#channels').empty();
+				$('#provider')
+					.html(options)
+					.children().first().addClass('ui-selected');
+				self.changeProvider(
+					$('#provider').children().first().data('sref'),
+					self.showChannels
+				);
 			},
-			error: function(jqXHR, textStatus, errorThrown) 
-			{
-				showError("Upload File Error: " + errorThrown);
-			}
-		});
-		e.preventDefault();
-		try {
-			e.unbind();
-		} catch(e){}
-	});
-	$('form#uploadrestore').submit();
-}
+		
+			// Callback for display left panel services list
+			showChannels: function (options) {
+				$('#channels').html(options);
+				self.setChannelButtons();
+			},
 
-function InitPage() {
+			// Callback for display right panel bouquet list
+			// Triggers fetching and displaying dependent services list
+			// for selected bouquet
+			showBouquets: function (options) {
+				$('#bql')
+					.html(options)
+					.children().first().addClass('ui-selected');
+				self.changeBouquet(
+					$('#bql').children().first().data('sref'),
+					self.showBouquetChannels
+				);
+			},
 
-	showError("");
+			// Callback for display right panel services list
+			showBouquetChannels: function (options) {
+				$('#bqs').html(options);
+				self.setBouquetChannelButtons();
+			},
+
+			// Build ref string for selecting services list
+			// @param type int which list to use
+			// @return string
+			buildRefStr: function (type) {
+				var r;
+				if (self.Mode === 0) {
+					r = '1:7:1:0:0:0:0:0:0:0:(type == 1) || (type == 17) || (type == 195) || (type == 25) || (type == 22) ';
+				} else {
+					r = '1:7:2:0:0:0:0:0:0:0:(type == 2) ';
+				}
+				if (type === 0) {
+					r += 'FROM BOUQUET "bouquets.';
+					r += (self.Mode === 0) ? 'tv' : 'radio';
+					r += '" ORDER BY bouquet';
+				} else if (type === 1) {
+					r += 'FROM PROVIDERS ORDER BY name';
+				} else if (type === 2) {
+					r += 'FROM SATELLITES ORDER BY satellitePosition';
+				} else if (type === 3) {
+					r+='ORDER BY name';
+				}
+				// console.log(r);
+				return encodeURIComponent(r);
+			},
+
+			// Callback function for TV/Radio button
+			// @param nmode int 
+			//        0: TV, 1: Radio, 3: initial setup, triggers reload
+			setTvRadioMode: function (nmode) {
+				var reload = false;
+				if (nmode !== self.Mode || nmode === 3) {
+					reload = true;
+				}
 	
-	$('#btn0').click(function(){ BQELoadTVR(0);});
-	$('#btn1').click(function(){ BQELoadTVR(1);});
-
-	$('#btn2').click(function(){ BQELoadSatellites();});
-	$('#btn3').click(function(){ BQELoadProvider();});
-	$('#btn4').click(function(){ BQELoadAll();});
-
-	$('#btn5').click(function(){ BQELoadBQ();});
-	$('#btn6').click(function(){ BQEBackup();});
-	$('#btn7').click(function(){ BQERestore();});
-
-	$("#tb1").buttonset();
-	$("#tb2").buttonset();
-	$("#tb3").buttonset();
-
-	$("#provider").selectable({
-		selected: function( event, ui ) {
-			$(ui.selected).addClass("ui-selected").siblings().removeClass("ui-selected");
-			changeProvider(ui.selected.id);
-		}
-	});
-
-	$("#channels").selectable({
-		stop: function() {
-			var _s = [];
-			$( ".ui-selected", this ).each(function() {
-				var index = $( "#channels li" ).index( this );
-				_s.push(index);
-			});
-			selsrccl=_s;
-			SetCHButtons();
-		}
-	});
-
-	$("#bqs").sortable({
-		handle: ".handle",
-		update: function( event, ui ) {
-			var newsort = $(this).sortable('toArray');
-			movec(newsort);
-		}
-		}).selectable({
-		filter: "li",
-		cancel: ".handle",
-		stop: function() {
-			var _s = [];
-			$( ".ui-selected", this ).each(function() {
-				var index = $( "#bqs li" ).index( this );
-				_s.push(index);
-			});
-			seldstcl = _s;
-			console.log(_s);
-			SetDestCHButtons();
-		}
-	});
-
-	$("#bql").sortable({
-		handle: ".handle",
-		update: function( event, ui ) {
-			var newsort = $(this).sortable('toArray');
-			movebq(newsort);
-		}
-		}).selectable({
-		filter: "li",
-		cancel: ".handle",
-		stop: function() {
-			var _s = [];
-			$( ".ui-selected", this ).each(function() {
-				var index = $( "#bql li" ).index( this );
-				_s.push(index);
-			});
-			seldstbl = _s;
-			SetBQButtons();
-			if(_s.length === 1)
-				changeBQidx(_s[0]);
-		}
-	});
-
-
-	$('#searchch').focus(function() { 
-		if ($(this).val() == "...") {
-			$(this).val('');
-		}
-	});
-
-	$('#searchch').keyup(function(){
-		if ($(this).data('val')!=this.value) {
-			searchChannel(this.value);
-		}
-		$(this).data('val', this.value);
-	});
-
-	$('#searchch').blur(function(){
-		if ($(this).val() == "") {
-			$(this).val('...');
-		}
-	});
-
-	SetBQButtons();
-
-	$('#btnaddc').prop( "disabled", true );
-	$('#btnadda').prop( "disabled", true );
-	$('#btnaddp').prop( "disabled", true );
-	$('#btnmadd').prop( "disabled", true );
-	$('#btnmgren').prop( "disabled", true );
+				if (nmode > 1) {
+					self.Mode = 0;
+				} else {
+					self.Mode = nmode;
+				}
 	
-	BQELoadTVR(3);
-	
-	$("#rfile").change(function() {
-		prepareRestore($(this));
-	});
-	
-}
+				if (self.cType === 0) {
+					self.getSatellites(self.showProviders);
+				} else if (self.cType === 1) {
+					self.getProviders(self.showProviders);
+				} else if (self.cType === 2) {
+					$('#sel0').hide();
+					self.getChannels(self.showChannels);
+				}
+			
+				if (reload) {
+					self.getBouquets(self.showBouquets);
+				}
+			},
 
-function showError(txt,st)
-{
-	st = typeof st !== 'undefined' ? st : "False";
-	$('#success').text("");
-	$('#error').text("");
-	if(st===true)
-		st="True";
-	if(st === "True")
-		$('#success').text(txt);
-	else
-		$('#error').text(txt);
-	if(txt!=="")
-		$('#errorbox').show();
-	else
-		$('#errorbox').hide();
-}
+			// Callback function for left pane "satellites" button.
+			// Fetches satellites list, param callback displays list.
+			// @param callback function
+			getSatellites: function (callback) {
+				self.cType = 0;
+				var ref = self.buildRefStr(2);
+				$.getJSON( '/api/getsatellites?sRef=' + ref, function ( data ) {
+					var options = '';
+					var s = data['satellites'];
+					$.each( s, function ( key, val ) {
+						var sref = val['service'];
+						var name = val['name'];
+						options += '<li class="ui-widget-content" data-sref="'+encodeURIComponent(sref)+'">'+name+'</li>';
+					});
+					if (callback) {
+						callback(options);
+					}
+				});
+			},
+		   
+			// Callback function for left pane "providers" button.
+			// Fetches provider list, param callback displays list.
+			// @param callback function
+			getProviders: function (callback) {
+				self.cType = 1;
+				var ref = self.buildRefStr(1);
+				$.getJSON( '/api/getservices?sRef=' + ref, function ( data ) {
+					var options = '';
+					var s = data['services'];
+					$.each( s, function ( key, val ) {
+						var sref = val['servicereference']
+						var name = val['servicename']
+						options += '<li class="ui-widget-content" data-sref="'+encodeURIComponent(sref)+'">'+name+'</li>';
+					});
+					if (callback) {
+						callback(options);
+					}
+				});
+			},
+		
+			// Callback function for left pane "channels" button.
+			// Fetches channels list, param callback displays list.
+			// @param callback function
+			getChannels: function (callback) {
+				self.cType = 2;
+				var ref = self.buildRefStr(3);
+				$.getJSON( '/api/getservices?sRef=' + ref, function ( data ) {
+					var options = '';
+					var s = data['services'];
+					$.each( s, function ( key, val ) {
+						var name = val['servicename']
+						options += '<li class="ui-widget-content">'+name+'</li>';
+					});
+					if (callback) {
+						callback(options);
+					}
+				});
+			},
+		
+			// Callback function for fetching right panel bouquets list.
+			// @param callback function display bouquets list
+			getBouquets: function (callback) {
+				var ref = self.buildRefStr(0);
+				$.getJSON( '/bouqueteditor/api/getservices?sRef=' + ref, function ( data ) {
+					var options = '';
+					var s = data['services'];
+					$.each( s, function ( key, val ) {
+						var sref = val['servicereference'];
+						var name = val['servicename'];
+						options += '<li class="ui-widget-content" data-sref="'+encodeURIComponent(sref)+'"><div class="handle"><span class="ui-icon ui-icon-carat-2-n-s"></span></div>'+name+'</li>';
+					});
+					if (callback) {
+						callback(options);
+					}
+				});
+			},
+
+			// Callback function for selecting provider in left panel
+			// providers list.
+			// @param sref string selected provider reference string 
+			// @param callback function display services list
+			changeProvider: function (sref, callback) {
+				$.getJSON( '/api/getservices?sRef=' + sref, function ( data ) {
+					var options = '';
+					var s = data['services'];
+					$.each( s, function ( key, val ) {
+						var sref = val['servicereference'];
+						var name = val['servicename'];
+						options += '<li class="ui-widget-content" data-sref="'+encodeURIComponent(sref)+'">'+name+'</li>';
+					});
+					if (callback) {
+						callback(options);
+					}
+				});
+			},
+		
+
+			// Callback function for selecting bouquet in right panel
+			// bouquets list.
+			// @param sref string selected bouquet reference string 
+			// @param callback function display services list
+			changeBouquet: function (sref, callback) {
+				$.getJSON( '/bouqueteditor/api/getservices?sRef=' + sref, function ( data ) {
+					var options = '';
+					var s = data['services'];
+					$.each( s, function ( key, val ) {
+						var sref = val['servicereference']
+						var name = val['servicename']
+						var m = (val['ismarker'] == 1) ? '<span style="float:right">(M)</span>' : '';
+						options += '<li class="ui-widget-content" data-ismarker="'+val['ismarker']+'" data-sref="'+encodeURIComponent(sref)+'"><div class="handle"><span class="ui-icon ui-icon-carat-2-n-s"></span></div>'+name+m+'</li>';
+					});
+					if (callback) {
+						callback(options);
+					}
+				});
+			},
+
+			// Callback function for adding selecting provider in left panel
+			// providers list to bouquets list
+			addProvider: function () {
+				var sref = $('#provider li.ui-selected').data('sref');
+				$.getJSON( '/bouqueteditor/api/addprovidertobouquetlist?sProviderRef=' + sref + '&mode=' + self.Mode, function ( data ) {
+					var r = data.Result;
+					if (r.length == 2) {
+						self.showError(r[1],r[0]);
+					}
+					self.getBouquets(self.showBouquets);
+				});
+			},
+
+			// Callback function for moving bouquet in bouquets list
+			moveBouquet: function (obj) {
+				$.getJSON( '/bouqueteditor/api/movebouquet?sBouquetRef='+ obj.sBouquetRef 
+					+ '&mode=' + obj.mode
+					+ '&position=' + obj.position, function () {});
+			},
+
+			// Callback function for bouquet add button in right pane
+			// Prompts for bouquet name
+			addBouquet: function () {
+				var newname = prompt(tstr_bqe_name_bouquet + ':');
+				if (newname.length) {
+					$.getJSON( '/bouqueteditor/api/addbouquet?name=' + encodeURIComponent(newname) + '&mode=' + self.Mode , function ( data ) {
+						var r = data.Result;
+						if (r.length == 2) {
+							self.showError(r[1],r[0]);
+						}
+						self.getBouquets(self.showBouquets);
+					});
+				}
+			},
+		
+			// Callback function for bouquet rename button in right pane
+			// Prompts for new bouquet name
+			renameBouquet: function () {
+				if ($('#bql li.ui-selected').length !== 1) {
+					return;
+				}
+				var item = $('#bql li.ui-selected');
+				var pos = item.index();
+				var sname = item.text();
+				var sref = item.data('sref');
+
+				var newname=prompt(tstr_bqe_rename_bouquet + ':', sname);
+				if (newname && newname!=sname){
+					$.getJSON( '/bouqueteditor/api/renameservice?sRef=' + sref + '&mode=' + self.Mode + '&newName=' + encodeURIComponent(newname), function ( data ) {
+						var r = data.Result;
+						if (r.length == 2) {
+							self.showError(r[1],r[0]);
+						}
+						self.getBouquets(self.showBouquets);
+					});
+				}
+			},
+
+			// Callback function for bouquet delete button in roght panel
+			// Prompts for confirmation
+			deleteBouquet: function () {
+				if ($('#bql li.ui-selected').length !== 1) {
+					return;
+				}
+				var sname = $('#bql li.ui-selected').text();
+				var sref = $('#bql li.ui-selected').data('sref');
+				if (confirm(tstr_bqe_del_bouquet_question + "\n" + sname + ' ?') === false) {
+					return;
+				}
+
+				$.getJSON( '/bouqueteditor/api/removebouquet?sBouquetRef=' + sref + '&mode=' + self.Mode, function ( data ) {
+					var r = data.Result;
+					if (r.length == 2) {
+						self.showError(r[1],r[0]);
+					}
+					self.getBouquets(self.showBouquets);
+				});
+			},
+
+			// Disable/enable left pane channel buttons on selection state
+			setChannelButtons: function () {
+				var enabled = $('#channels li.ui-selected').length == 0;
+				$('#btn-channel-add').prop( 'disabled', enabled );
+				$('#btn-alternative-add').prop( 'disabled', enabled );
+			},
+
+			// Disable/enable right pane channel buttons on selection state
+			setBouquetChannelButtons: function () {
+				var item = $('#bqs li.ui-selected');
+				var state = item.length == 0;
+				$('#btn-channel-delete').prop( 'disabled', state );
+				$('#btn-marker-add').prop( 'disabled', state );
+
+				state = item.length != 1 || item.data('ismarker') != 1;
+				$('#btn-marker-group-rename').prop( "disabled", state );
+			},
+
+			// Callback function for moving service in right pane services list
+			moveChannel: function (obj) {
+				$.getJSON( '/bouqueteditor/api/moveservice?sBouquetRef='+ obj.sBouquetRef 
+					+ '&sRef=' + obj.sRef + '&mode=' + obj.mode
+					+ '&position=' + obj.position, function () {});
+			},
+
+			// Add selected services from left pane channels list to right pane channels list
+			// Services will be added before selected service in right pane.
+			addChannel: function () {
+				var reqjobs = [];
+				var bref = $('#bql li.ui-selected').data('sref');
+				var dstref = $('#bqs li.ui-selected').data('sref') || '';
+			
+				$('#channels li.ui-selected').each(function () {
+					reqjobs.push($.getJSON( '/bouqueteditor/api/addservicetobouquet?sBouquetRef=' + bref + '&sRef=' + $(this).data('sref') + '&sRefBefore=' + dstref, function () {}));
+				});
+
+				if (reqjobs.length !== 0) {
+					$.when.apply($, reqjobs).then(function () {
+						self.changeBouquet(bref, self.showBouquetChannels);
+					});
+				}
+			},
+
+			// TBD.
+			addAlternative: function () {
+				alert('NOT implemented YET');
+				return;
+			},
+
+			// Callback function for right pane delete channel button
+			// Deletes selected services, prompts for confirmation.
+			deleteChannel: function () {
+				if ($('#bqs li.ui-selected').length === 0) {
+					return;
+				}
+
+				var bref = $('#bql li.ui-selected').data('sref');
+				var snames = [];
+				var jobs = [];
+				var jobtemplate = '/bouqueteditor/api/removeservice?sBouquetRef=' + bref + '&mode=' + self.Mode + '&sRef=';
+
+				$('#bqs li.ui-selected').each(function () { 
+					snames.push($(this).text());
+					jobs.push( jobtemplate + $(this).data('sref') );
+				});
+			
+				if (confirm(tstr_bqe_del_channel_question + "\n" + snames.join(', ') + ' ?') === false) {
+					return;
+				}
+
+				var reqjobs = [];
+				$.each( jobs, function ( key, job ) {
+					reqjobs.push($.getJSON(job, function (){}));
+				});
+
+				if (reqjobs.length !== 0) {
+					$.when.apply($, reqjobs).then(function () {
+						self.changeBouquet(bref, self.showBouquetChannels);
+					});
+				}
+			},
+
+			// Callback function for right pane add marker button
+			// Prompts for marker name, marker will be added before selected service
+			addMarker: function () {
+				var newname = prompt(tstr_bqe_name_marker + ':');
+				if (newname.length) {
+	
+					var bref = $('#bql li.ui-selected').data('sref');
+					var dstref = $('#bqs li.ui-selected').data('sref') || '';
+		
+					$.getJSON( '/bouqueteditor/api/addmarkertobouquet?sBouquetRef=' + bref + '&Name=' + encodeURIComponent(newname) +'&sRefBefore=' + dstref , function ( data ) {
+						var r = data.Result;
+						if (r.length == 2) {
+							self.showError(r[1],r[0]);
+						}
+						self.changeBouquet(bref, self.showBouquetChannels);
+					});
+				}
+			},
+
+			// Callback function for right panel rename marker button
+			// At the moment only markers will be renamed. Prompts for new marker name.
+			renameMarkerGroup: function () {
+				// rename marker or group
+				var item = $('#bqs li.ui-selected');
+				if (item.length !== 1) {
+					return;
+				}
+
+				// TODO : rename group
+				if (item.data('ismarker') == 0) {
+					return;
+				}
+			
+				var pos = item.index()
+				var sname = item.text();
+				var sref = item.data('sref');
+				var bref = $('#bql li.ui-selected').data('sref');
+				var dstref = $('#bqs li.ui-selected').next().data('sref') || '';
+
+				var newname = prompt(tstr_bqe_rename_marker + ': ', sname);
+				if (newname && newname !== sname) {
+					$.getJSON( '/bouqueteditor/api/renameservice?sBouquetRef=' + bref + '&sRef=' + sref + '&newName=' + encodeURIComponent(newname) + '&sRefBefore=' + dstref, function ( data ) {
+						var r = data.Result;
+						if (r.length == 2) {
+							self.showError(r[1],r[0]);
+						}
+						self.changeBouquet(bref, self.showBouquetChannels);
+					});
+				}
+			},
+
+			// Callback function for search box in left pane
+			// Filters matching services in channels list. 
+			searchChannel: function (txt) {
+				var t = txt.toLowerCase();
+				$( '#channels li').each(function (){
+					if ($(this).text().toLowerCase().indexOf(t) !== -1) {
+						$(this).show();
+					} else {
+						$(this).hide();
+					}
+				});
+	
+				$('#channels li.ui-selected').removeClass('ui-selected');
+				self.setChannelButtons();
+			},
+
+			// Display success and errors for selected ajax functions
+			// @param txt string success/error msg
+			// @param st bool False: error, True: success
+			showError: function (txt, st) {
+				st = typeof st !== 'undefined' ? st : 'False';
+				$('#success').text('');
+				$('#error').text('');
+			
+				if (st === true || st === 'True') {
+					$('#success').text(txt);
+				} else {
+					$('#error').text(txt);
+				}
+			
+				if (txt !== '') {
+					$('#errorbox').show();
+				} else {
+					$('#errorbox').hide();
+				}
+			},
+
+			// Callback function for export button in right pane.
+			// Prompts for backup file name
+			exportBouquets: function () {
+				var fn = prompt(tstr_bqe_filename + ': ', 'bouquets_backup');
+				if (fn) {
+					$.getJSON( '/bouqueteditor/api/backup?Filename='+fn, function ( data ) {
+						var r = data.Result;
+						if (r[0] === false) {
+							showError(r[1],r[0]);
+						} else {
+							var url =  "/bouqueteditor/tmp/" + r[1];
+							window.open(url,'Download');
+						}
+					});
+				}
+			},
+
+			// Callback function for import button in right pane.
+			// Triggers file upload dialog.
+			importBouquets: function () {
+				$("#rfile").trigger('click');
+			},
+
+			// Callback function for import button in right pane.
+			// Called after file upload dialog. Prompts for confirmation of upload,
+			// uploads backup file.
+			prepareRestore: function () {
+				var fn = $(this).val();
+				fn = fn.replace('C:\\fakepath\\','');
+				if (confirm(tstr_bqe_restore_question + ' ( ' + fn + ') ?') === false) {
+					return;
+				}
+	
+				$('form#uploadrestore')
+					.unbind('submit')
+					.submit(function (e) 
+				{
+					var formData = new FormData(this);
+					$.ajax({
+						url: '/bouqueteditor/uploadrestore',
+						type: 'POST',
+						data:  formData,
+						mimeType:"multipart/form-data",
+						contentType: false,
+						cache: false,
+						processData:false,
+						dataType: "json",
+						success: function (data, textStatus, jqXHR) {
+							var r = data.Result;
+							if (r[0]) {
+								self.doRestore(r[1]);
+							} else {
+								self.showError("Upload File: " + textStatus);
+							}
+						},
+						error: function (jqXHR, textStatus, errorThrown) {
+							self.showError("Upload File Error: " + errorThrown);
+						}
+					});
+					e.preventDefault();
+					try {
+						e.unbind();
+					} catch(e){}
+				});
+				$('form#uploadrestore').submit();
+			},
+
+			// Callback function for restoring uploaded bouquet backup file
+			doRestore: function (fn) {
+				if (fn) {
+					$.getJSON( '/bouqueteditor/api/restore?Filename='+fn, function ( data ) {
+						// console.log(data);
+						var r = data.Result;
+						if (r.length == 2) {
+							self.showError(r[1],r[0]);
+						}
+					});
+				}
+			},
+
+			// Setup handlers, trigger building lists.
+			// This is the starting point.
+			setup: function () {
+				self = this;
+				self.Mode = 0;
+				self.cType = 1;
+
+				// Styled button sets; #tb1, #tb2 in left pane, #tb3 in right pane
+				$('#tb1').buttonset();
+				$('#tb2').buttonset();
+				$('#tb3').buttonset();
+
+				// Setup callback functions in left pane
+				$('#btn-provider-add').click(self.addProvider);
+				$('#btn-channel-add').click(self.addChannel);
+				$('#btn-alternative-add').click(self.addAlternative);
+
+				// Setup callback functions in right pane
+				$('#btn-bouquet-add').click(self.addBouquet);
+				$('#btn-bouquet-rename').click(self.renameBouquet);
+				$('#btn-bouquet-delete').click(self.deleteBouquet);
+
+				$('#btn-channel-delete').click(self.deleteChannel);
+				$('#btn-marker-add').click(self.addMarker);
+				$('#btn-marker-group-rename').click(self.renameMarkerGroup);
+
+				// Setup selection callback function for left pane providers list
+				// Triggers building services list for selected provider
+				$('#provider').selectable({
+					selected: function ( event, ui ) {
+						$(ui.selected).addClass('ui-selected').siblings().removeClass('ui-selected');
+						self.changeProvider($(ui.selected).data('sref'), self.showChannels);
+					}
+				});
+
+				// Setup selection callback function for left pane channels list
+				$('#channels').selectable({
+					stop: self.setChannelButtons
+				});
+
+				// Setup callback functions for right pane bouquets list
+				// Sorting is done via sortable widget, selection via selectable
+				// widget triggers building of channels list for selected bouquet.
+				$('#bql').sortable({
+					handle: '.handle',
+					stop: function ( event, ui ) {
+						var sref = $(ui.item).data('sref');
+						var position = ui.item.index();
+						self.moveBouquet({ sBouquetRef: sref, mode: self.Mode, position: position});
+					}
+				}).selectable({
+					filter: 'li',
+					cancel: '.handle',
+					selected: function ( event, ui ) {
+						$(ui.selected).addClass('ui-selected').siblings().removeClass('ui-selected');
+						self.changeBouquet($(ui.selected).data('sref'), self.showBouquetChannels);
+					}
+				});
+
+				// Setup callback functions for right pane channels list
+				// Sorting is done via sortable widget.
+				$('#bqs').sortable({
+					handle: '.handle',
+					stop: function ( event, ui ) {
+						var bref = $('#bql li.ui-selected').data('sref');
+						var sref = $(ui.item).data('sref');
+						var position = ui.item.index();
+						self.moveChannel({ sBouquetRef: bref, sRef: sref, mode: self.Mode, position: position});
+					}
+				}).selectable({
+					filter: 'li',
+					cancel: '.handle',
+					stop: self.setBouquetChannelButtons
+				});
+
+				// Setup callback functions for left pane toolbar buttons
+				$('#toolbar-choose-tv').click(function () { self.setTvRadioMode(0); });
+				$('#toolbar-choose-radio').click(function () { self.setTvRadioMode(1); });
+
+				$('#toolbar-choose-satellites').click(function () { self.getSatellites(self.showProviders); });
+				$('#toolbar-choose-providers').click(function () { self.getProviders(self.showProviders); });
+				$('#toolbar-choose-channels').click(function () { 
+					$('#sel0').hide();
+					$('#btn-provider-add').hide();
+					self.getChannels(self.showChannels); 
+				});
+
+				// Setup callback functions for right pane toolbar buttons
+				$('#toolbar-bouquets-reload').click(function () { self.getBouquets(self.showBouquets); });
+				$('#toolbar-bouquets-export').click(self.exportBouquets);
+				$('#toolbar-bouquets-import').click(self.importBouquets);
+
+				// Setup callback function for left pane search box
+				$('#searchch').focus(function () { 
+					if ($(this).val() === '...') {
+						$(this).val('');
+					}
+				}).keyup(function (){
+					if ($(this).data('val') !== this.value) {
+						self.searchChannel(this.value);
+					}
+					$(this).data('val', this.value);
+				}).blur(function (){
+					$(this).data('val', '');
+					if ($(this).val() === '') {
+						$(this).val('...');
+					}
+				});
+
+				// Setup callback function hidden file upload button
+				$('#rfile').change(self.prepareRestore);
+
+				// Initially build all lists.
+				self.setTvRadioMode(3);
+			},
+		 }
+	};
+
+	var bqe = new BQE();
+	bqe.setup();
+
+})();

--- a/plugin/public/js/bqe.js
+++ b/plugin/public/js/bqe.js
@@ -24,6 +24,9 @@
 		// keep track of which list in left pane is shown.
 		// 0: satellites, 1: providers, 2: all channels
 		var cType;
+		
+		// Array of services type markers.
+		var sType;
 
 		return {
 			// Callback for display left panel providers list
@@ -75,7 +78,7 @@
 			buildRefStr: function (type) {
 				var r;
 				if (self.Mode === 0) {
-					r = '1:7:1:0:0:0:0:0:0:0:(type == 1) || (type == 17) || (type == 195) || (type == 25) || (type == 22) ';
+					r = '1:7:1:0:0:0:0:0:0:0:(type == 1) || (type == 17) || (type == 195) || (type == 25) || (type == 22) || (type == 31) || (type == 211) ';
 				} else {
 					r = '1:7:2:0:0:0:0:0:0:0:(type == 2) ';
 				}
@@ -96,7 +99,7 @@
 
 			// Callback function for TV/Radio button
 			// @param nmode int 
-			//        0: TV, 1: Radio, 3: initial setup, triggers reload
+			//        0: TV, 1: Radio, 2: Option, 3: initial setup, triggers reload
 			setTvRadioMode: function (nmode) {
 				var reload = false;
 				if (nmode !== self.Mode || nmode === 3) {
@@ -173,8 +176,11 @@
 					var options = '';
 					var s = data['services'];
 					$.each( s, function ( key, val ) {
-						var name = val['servicename']
-						options += '<li class="ui-widget-content">'+name+'</li>';
+						var sref = val['servicereference'];
+						var name = val['servicename'];
+						var stype = sref.split(':')[2];
+						var m = '<span class="marker">' + (self.sType[stype] || '') + '</span>';
+						options += '<li class="ui-widget-content" data-stype="'+stype+'" data-sref="'+encodeURIComponent(sref)+'">'+name+m+'</li>';
 					});
 					if (callback) {
 						callback(options);
@@ -211,7 +217,9 @@
 					$.each( s, function ( key, val ) {
 						var sref = val['servicereference'];
 						var name = val['servicename'];
-						options += '<li class="ui-widget-content" data-sref="'+encodeURIComponent(sref)+'">'+name+'</li>';
+						var stype = sref.split(':')[2];
+						var m = '<span class="marker">' + (self.sType[stype] || '') + '</span>';
+						options += '<li class="ui-widget-content" data-stype="'+stype+'" data-sref="'+encodeURIComponent(sref)+'">'+name+m+'</li>';
 					});
 					if (callback) {
 						callback(options);
@@ -575,6 +583,7 @@
 				self = this;
 				self.Mode = 0;
 				self.cType = 1;
+				self.sType = { '1': '[SD]', '16': '[SD4]', '19': '[HD]', '1F': '[UHD]', 'D3': '[OPT]' };
 
 				// Styled button sets; #tb1, #tb2 in left pane, #tb3 in right pane
 				$('#tb1').buttonset();


### PR DESCRIPTION
Bouquet Editor: Adding channel on last position or moving channels over 4 positions not possible.

The patch 
* fixes issue #377
* refactores bouquet editor javascript into a class ( I had a hard time to understand how it was working)
* commented methods, renamed methods and buttons to be more descriptive

The "what changed" in bqe.js probably deserves an explanation. Basically I got rid of the tracking arrays for the service reference lists. Instead the information now is stored as data on the &lt;li&gt; objects itself. That made moving a service entry as simple as making one ajax request. 

The lists became out of sync because the API changed the lists on the box differently from what the housekeeping of the javascript lists suggested.

Please consider merging.

Cheers,
Robert