### PR TITLE
[ajax.py] - allow png to be used as boximage

### DIFF
--- a/plugin/controllers/ajax.py
+++ b/plugin/controllers/ajax.py
@@ -93,7 +93,9 @@ class AjaxController(BaseController):
 		info = getInfo()
 		type = getBoxType()
 
-		if fileExists(getPublicPath("/images/boxes/"+type+".jpg")):
+		if fileExists(getPublicPath("/images/boxes/"+type+".png")):
+			info["boximage"] = type+".png"
+		elif fileExists(getPublicPath("/images/boxes/"+type+".jpg")):
 			info["boximage"] = type+".jpg"
 		else:
 			info["boximage"] = "unknown.jpg"


### PR DESCRIPTION
if a png exists - the png is used
![png-available-png-is-used](https://cloud.githubusercontent.com/assets/4148122/19626822/86ba6d82-9939-11e6-83b0-03fd145b9da5.jpg)


if a png does not exist - the jpg is used
![no-png-available-jpg-is-used](https://cloud.githubusercontent.com/assets/4148122/19626821/7aa9f36e-9939-11e6-896c-b324a419236c.jpg)

if none of them exist - unknown is used

maybe it could be implemented in a better way. Due to theme implementation usage of png for boximage looks much better in different backgroundcolors.

It does not break current functionality - as long no png is shipped, jpg is still used.
