### PR TITLE
Correctly handle empty password

### DIFF
--- a/plugin/httpserver.py
+++ b/plugin/httpserver.py
@@ -365,7 +365,7 @@ class AuthResource(resource.Resource):
 					cpass = getspnam(user)[1]
 				except:
 					return False
-			return crypt(passwd, cpass) == cpass
+			return not cpass or crypt(passwd, cpass) == cpass
 		return False
 
 #


### PR DESCRIPTION
If the password is empty, crypt will return None and the comparison
against cpass will fail. Explicitly check for empty password to
handle this case.