### PR TITLE
adding both xml and json content type headers to apis

### DIFF
--- a/plugin/public/webtv/webtv.js
+++ b/plugin/public/webtv/webtv.js
@@ -276,6 +276,7 @@ var PlayerObj = function () {
 			$.ajax({
 				url: '/api/movielist',
 				dataType: 'json',
+                contentType: "application/json; charset=utf-8",
 				cache: false,
 				data: rdata,
 				success: function ( data ) {

--- a/plugin/public/webtv/webtv.js
+++ b/plugin/public/webtv/webtv.js
@@ -276,7 +276,7 @@ var PlayerObj = function () {
 			$.ajax({
 				url: '/api/movielist',
 				dataType: 'json',
-                contentType: "application/json; charset=utf-8",
+				contentType: "application/json; charset=utf-8",
 				cache: false,
 				data: rdata,
 				success: function ( data ) {

--- a/sourcefiles/js/at.js
+++ b/sourcefiles/js/at.js
@@ -734,6 +734,7 @@ function delAT()
 		$.ajax({
 			type: "GET", url: "/autotimer/remove?id=" + CurrentAT.id,
 			dataType: "xml",
+			contentType: "application/xml; charset=utf-8",
 			success: function (xml)
 			{
 				var state=$(xml).find("e2state").first();
@@ -755,6 +756,7 @@ function readAT()
 	$.ajax({
 		type: "GET", url: "/autotimer",
 		dataType: "xml",
+		contentType: "application/xml; charset=utf-8",
 		success: function (xml)
 		{
 			atxml=xml;
@@ -957,6 +959,7 @@ function saveAT()
 		$.ajax({
 			type: "GET", url: reqs,
 			dataType: "xml",
+			contentType: "application/xml; charset=utf-8",
 			success: function (xml)
 			{
 				var state=$(xml).find("e2state").first();
@@ -979,6 +982,7 @@ function simulateAT()
 	$.ajax({
 		type: "GET", url: "/autotimer/simulate",
 		dataType: "xml",
+		contentType: "application/xml; charset=utf-8",
 		success: function (xml)
 		{
 			var lines= [];
@@ -1017,6 +1021,7 @@ function parseAT()
 	$.ajax({
 		type: "GET", url: "/autotimer/parse",
 		dataType: "xml",
+		contentType: "application/xml; charset=utf-8",
 		success: function (xml)
 		{
 			var state=$(xml).find("e2state").first();
@@ -1059,6 +1064,7 @@ function getAutoTimerSettings()
 	$.ajax({
 		type: "GET", url: "/autotimer/get",
 		dataType: "xml",
+		contentType: "application/xml; charset=utf-8",
 		success: function (xml)
 		{
 			var settings = [];
@@ -1115,6 +1121,7 @@ function setAutoTimerSettings()
 	$.ajax({
 		type: "GET", url: reqs,
 		dataType: "xml",
+		contentType: "application/xml; charset=utf-8",
 		success: function (xml)
 		{
 			var state=$(xml).find("e2state").first();

--- a/sourcefiles/js/bqe.js
+++ b/sourcefiles/js/bqe.js
@@ -168,7 +168,7 @@
 				$.ajax({
 					url: '/api/getsatellites',
 					dataType: 'json',
-		            contentType: "application/json; charset=utf-8",
+					contentType: "application/json; charset=utf-8",
 					cache: true,
 					data: { sRef: ref, stype: stype, date: self.date },
 					success: function ( data ) {
@@ -198,7 +198,7 @@
 				$.ajax({
 					url: '/api/getservices',
 					dataType: 'json',
-		            contentType: "application/json; charset=utf-8",
+					contentType: "application/json; charset=utf-8",
 					cache: true,
 					data: { sRef: ref, date: self.date },
 					success: function ( data ) {
@@ -228,7 +228,7 @@
 				$.ajax({
 					url: '/api/getservices?sRef=' + ref,
 					dataType: 'json',
-		            contentType: "application/json; charset=utf-8",
+					contentType: "application/json; charset=utf-8",
 					cache: true,
 					data: { sRef: ref, date: self.date },
 					success: function ( data ) {
@@ -264,7 +264,7 @@
 				$.ajax({
 					url: '/bouqueteditor/api/getservices',
 					dataType: 'json',
-		            contentType: "application/json; charset=utf-8",
+					contentType: "application/json; charset=utf-8",
 					cache: false,
 					data: { sRef: ref },
 					success: function ( data ) {
@@ -293,7 +293,7 @@
 				$.ajax({
 					url: '/api/getservices',
 					dataType: 'json',
-		            contentType: "application/json; charset=utf-8",
+					contentType: "application/json; charset=utf-8",
 					cache: true,
 					data: { sRef: sref, date: self.date },
 					success: function ( data ) {
@@ -312,7 +312,7 @@
 				$.ajax({
 					url: '/bouqueteditor/api/getservices',
 					dataType: 'json',
-		            contentType: "application/json; charset=utf-8",
+					contentType: "application/json; charset=utf-8",
 					cache: false,
 					data: { sRef: sref },
 					success: function ( data ) {
@@ -349,7 +349,7 @@
 				$.ajax({
 					url: '/bouqueteditor/api/addprovidertobouquetlist',
 					dataType: 'json',
-		            contentType: "application/json; charset=utf-8",
+					contentType: "application/json; charset=utf-8",
 					cache: true,
 					data: { sProviderRef: sref, mode: self.Mode, date: self.date },
 					success: function ( data ) {
@@ -367,7 +367,7 @@
 				$.ajax({
 					url: '/bouqueteditor/api/movebouquet',
 					dataType: 'json',
-		            contentType: "application/json; charset=utf-8",
+					contentType: "application/json; charset=utf-8",
 					cache: false,
 					data: { sBouquetRef: obj.sBouquetRef, mode: obj.mode, position: obj.position },
 					success: function () {}
@@ -382,7 +382,7 @@
 					$.ajax({
 						url: '/bouqueteditor/api/addbouquet',
 						dataType: 'json',
-		                contentType: "application/json; charset=utf-8",
+						contentType: "application/json; charset=utf-8",
 						cache: false,
 						data: { name: newname, mode: self.Mode },
 						success: function ( data ) {
@@ -412,7 +412,7 @@
 					$.ajax({
 						url: '/bouqueteditor/api/renameservice',
 						dataType: 'json',
-		                contentType: "application/json; charset=utf-8",
+						contentType: "application/json; charset=utf-8",
 						cache: false,
 						data: { sRef: sref, mode: self.Mode, newName: newname },
 						success: function ( data ) {
@@ -441,7 +441,7 @@
 				$.ajax({
 					url: '/bouqueteditor/api/removebouquet',
 					dataType: 'json',
-		            contentType: "application/json; charset=utf-8",
+					contentType: "application/json; charset=utf-8",
 					cache: false,
 					data: { sBouquetRef: sref, mode: self.Mode },
 					success: function ( data ) {
@@ -478,7 +478,7 @@
 				$.ajax({
 					url: '/bouqueteditor/api/moveservice',
 					dataType: 'json',
-		            contentType: "application/json; charset=utf-8",
+					contentType: "application/json; charset=utf-8",
 					cache: false,
 					data: {
 						sBouquetRef: obj.sBouquetRef,
@@ -506,7 +506,7 @@
 					reqjobs.push($.ajax({
 						url: '/bouqueteditor/api/addservicetobouquet',
 						dataType: 'json',
-		                contentType: "application/json; charset=utf-8",
+						contentType: "application/json; charset=utf-8",
 						cache: false,
 						data: {
 							sBouquetRef: bref,
@@ -559,7 +559,7 @@
 					reqjobs.push($.ajax({
 						url: '/bouqueteditor/api/removeservice',
 						dataType: 'json',
-		                contentType: "application/json; charset=utf-8",
+						contentType: "application/json; charset=utf-8",
 						cache: false,
 						data: jobdata,
 						success: function (){}
@@ -593,7 +593,7 @@
 					$.ajax({
 						url: '/bouqueteditor/api/addmarkertobouquet',
 						dataType: 'json',
-		                contentType: "application/json; charset=utf-8",
+						contentType: "application/json; charset=utf-8",
 						cache: false,
 						data: params,
 						success: function ( data ) {
@@ -632,7 +632,7 @@
 					$.ajax({
 						url: '/bouqueteditor/api/renameservice',
 						dataType: 'json',
-		                contentType: "application/json; charset=utf-8",
+						contentType: "application/json; charset=utf-8",
 						cache: false,
 						data: { sBouquetRef: bref, sRef: sref, newName: newname, sRefBefore: dstref },
 						success: function ( data ) {
@@ -696,7 +696,7 @@
 					$.ajax({
 						url: '/bouqueteditor/api/backup',
 						dataType: 'json',
-		                contentType: "application/json; charset=utf-8",
+						contentType: "application/json; charset=utf-8",
 						cache: false,
 						data: { Filename: fn },
 						success: function ( data ) {
@@ -742,7 +742,7 @@
 						cache: false,
 						processData:false,
 						dataType: 'json',
-		                contentType: "application/json; charset=utf-8",
+						contentType: "application/json; charset=utf-8",
 						success: function (data, textStatus, jqXHR) {
 							var r = data.Result;
 							if (r[0]) {
@@ -769,7 +769,7 @@
 					$.ajax({
 						url: '/bouqueteditor/api/restore',
 						dataType: 'json',
-		                contentType: "application/json; charset=utf-8",
+						contentType: "application/json; charset=utf-8",
 						cache: false,
 						data: { Filename: fn }, 
 						success: function ( data ) {

--- a/sourcefiles/js/bqe.js
+++ b/sourcefiles/js/bqe.js
@@ -168,6 +168,7 @@
 				$.ajax({
 					url: '/api/getsatellites',
 					dataType: 'json',
+		            contentType: "application/json; charset=utf-8",
 					cache: true,
 					data: { sRef: ref, stype: stype, date: self.date },
 					success: function ( data ) {
@@ -187,7 +188,7 @@
 					}
 				});
 			},
-		
+
 			// Callback function for left pane "providers" button.
 			// Fetches provider list, param callback displays list.
 			// @param callback function
@@ -195,8 +196,9 @@
 				self.cType = 1;
 				var ref = self.buildRefStr(1);
 				$.ajax({
-					url: '/api/getservices', 
+					url: '/api/getservices',
 					dataType: 'json',
+		            contentType: "application/json; charset=utf-8",
 					cache: true,
 					data: { sRef: ref, date: self.date },
 					success: function ( data ) {
@@ -216,7 +218,7 @@
 					}
 				});
 			},
-		
+
 			// Callback function for left pane "channels" button.
 			// Fetches channels list, param callback displays list.
 			// @param callback function
@@ -224,8 +226,9 @@
 				self.cType = 2;
 				var ref = self.buildRefStr(3);
 				$.ajax({
-					url: '/api/getservices?sRef=' + ref, 
+					url: '/api/getservices?sRef=' + ref,
 					dataType: 'json',
+		            contentType: "application/json; charset=utf-8",
 					cache: true,
 					data: { sRef: ref, date: self.date },
 					success: function ( data ) {
@@ -235,7 +238,7 @@
 					}
 				});
 			},
-			
+
 			fillChannels: function (callback)
 			{
 				var options = [];
@@ -253,14 +256,15 @@
 					callback(options);
 				}
 			},
-			
+
 			// Callback function for fetching right panel bouquets list.
 			// @param callback function display bouquets list
 			getBouquets: function (callback) {
 				var ref = self.buildRefStr(0);
 				$.ajax({
-					url: '/bouqueteditor/api/getservices', 
+					url: '/bouqueteditor/api/getservices',
 					dataType: 'json',
+		            contentType: "application/json; charset=utf-8",
 					cache: false,
 					data: { sRef: ref },
 					success: function ( data ) {
@@ -283,12 +287,13 @@
 
 			// Callback function for selecting provider in left panel
 			// providers list.
-			// @param sref string selected provider reference string 
+			// @param sref string selected provider reference string
 			// @param callback function display services list
 			changeProvider: function (sref, callback) {
 				$.ajax({
-					url: '/api/getservices', 
+					url: '/api/getservices',
 					dataType: 'json',
+		            contentType: "application/json; charset=utf-8",
 					cache: true,
 					data: { sRef: sref, date: self.date },
 					success: function ( data ) {
@@ -301,12 +306,13 @@
 
 			// Callback function for selecting bouquet in right panel
 			// bouquets list.
-			// @param sref string selected bouquet reference string 
+			// @param sref string selected bouquet reference string
 			// @param callback function display services list
 			changeBouquet: function (sref, callback) {
 				$.ajax({
-					url: '/bouqueteditor/api/getservices', 
+					url: '/bouqueteditor/api/getservices',
 					dataType: 'json',
+		            contentType: "application/json; charset=utf-8",
 					cache: false,
 					data: { sRef: sref },
 					success: function ( data ) {
@@ -323,7 +329,7 @@
 							if(name!='')
 								options.push( $('<li/>', {
 									class: "ui-widget-content",
-									data: { 
+									data: {
 										ismarker: val['ismarker'],
 										sref: sref
 									}
@@ -341,8 +347,9 @@
 			addProvider: function () {
 				var sref = $('#provider li.ui-selected').data('sref');
 				$.ajax({
-					url: '/bouqueteditor/api/addprovidertobouquetlist', 
+					url: '/bouqueteditor/api/addprovidertobouquetlist',
 					dataType: 'json',
+		            contentType: "application/json; charset=utf-8",
 					cache: true,
 					data: { sProviderRef: sref, mode: self.Mode, date: self.date },
 					success: function ( data ) {
@@ -360,6 +367,7 @@
 				$.ajax({
 					url: '/bouqueteditor/api/movebouquet',
 					dataType: 'json',
+		            contentType: "application/json; charset=utf-8",
 					cache: false,
 					data: { sBouquetRef: obj.sBouquetRef, mode: obj.mode, position: obj.position },
 					success: function () {}
@@ -374,8 +382,9 @@
 					$.ajax({
 						url: '/bouqueteditor/api/addbouquet',
 						dataType: 'json',
+		                contentType: "application/json; charset=utf-8",
 						cache: false,
-						data: { name: newname, mode: self.Mode }, 
+						data: { name: newname, mode: self.Mode },
 						success: function ( data ) {
 							var r = data.Result;
 							if (r.length == 2) {
@@ -386,7 +395,7 @@
 					});
 				}
 			},
-		
+
 			// Callback function for bouquet rename button in right pane
 			// Prompts for new bouquet name
 			renameBouquet: function () {
@@ -403,8 +412,9 @@
 					$.ajax({
 						url: '/bouqueteditor/api/renameservice',
 						dataType: 'json',
+		                contentType: "application/json; charset=utf-8",
 						cache: false,
-						data: { sRef: sref, mode: self.Mode, newName: newname }, 
+						data: { sRef: sref, mode: self.Mode, newName: newname },
 						success: function ( data ) {
 							var r = data.Result;
 							if (r.length == 2) {
@@ -431,8 +441,9 @@
 				$.ajax({
 					url: '/bouqueteditor/api/removebouquet',
 					dataType: 'json',
+		            contentType: "application/json; charset=utf-8",
 					cache: false,
-					data: { sBouquetRef: sref, mode: self.Mode }, 
+					data: { sBouquetRef: sref, mode: self.Mode },
 					success: function ( data ) {
 						var r = data.Result;
 						if (r.length == 2) {
@@ -467,13 +478,14 @@
 				$.ajax({
 					url: '/bouqueteditor/api/moveservice',
 					dataType: 'json',
+		            contentType: "application/json; charset=utf-8",
 					cache: false,
-					data: { 
-						sBouquetRef: obj.sBouquetRef, 
-						sRef: obj.sRef, 
-						mode: obj.mode,  
-						position: obj.position 
-					}, 
+					data: {
+						sBouquetRef: obj.sBouquetRef,
+						sRef: obj.sRef,
+						mode: obj.mode,
+						position: obj.position
+					},
 					success:self.renumberChannel
 				});
 			},
@@ -489,18 +501,19 @@
 				var reqjobs = [];
 				var bref = $('#bql li.ui-selected').data('sref');
 				var dstref = $('#bqs li.ui-selected').data('sref') || '';
-			
+
 				$('#channels li.ui-selected').each(function () {
 					reqjobs.push($.ajax({
 						url: '/bouqueteditor/api/addservicetobouquet',
 						dataType: 'json',
+		                contentType: "application/json; charset=utf-8",
 						cache: false,
-						data: { 
+						data: {
 							sBouquetRef: bref,
 							sRef: $(this).data('sref'),
-							sRefBefore: dstref 
-						}, 
-						success: function () {} 
+							sRefBefore: dstref
+						},
+						success: function () {}
 					}));
 				});
 
@@ -528,7 +541,7 @@
 				var snames = [];
 				var jobs = [];
 
-				$('#bqs li.ui-selected').each(function () { 
+				$('#bqs li.ui-selected').each(function () {
 					snames.push( $(this).text() );
 					jobs.push({
 						sBouquetRef: bref,
@@ -536,7 +549,7 @@
 						sRef: $(this).data('sref')
 					});
 				});
-			
+
 				if (confirm(tstr_bqe_del_channel_question + "\n" + snames.join(', ') + ' ?') === false) {
 					return;
 				}
@@ -546,9 +559,10 @@
 					reqjobs.push($.ajax({
 						url: '/bouqueteditor/api/removeservice',
 						dataType: 'json',
+		                contentType: "application/json; charset=utf-8",
 						cache: false,
-						data: jobdata, 
-						success: function (){} 
+						data: jobdata,
+						success: function (){}
 					}));
 				});
 
@@ -579,8 +593,9 @@
 					$.ajax({
 						url: '/bouqueteditor/api/addmarkertobouquet',
 						dataType: 'json',
+		                contentType: "application/json; charset=utf-8",
 						cache: false,
-						data: params, 
+						data: params,
 						success: function ( data ) {
 							var r = data.Result;
 							if (r.length == 2) {
@@ -605,7 +620,7 @@
 				if (item.data('ismarker') == 0) {
 					return;
 				}
-			
+
 				var pos = item.index()
 				var sname = item.text();
 				var sref = item.data('sref');
@@ -617,8 +632,9 @@
 					$.ajax({
 						url: '/bouqueteditor/api/renameservice',
 						dataType: 'json',
+		                contentType: "application/json; charset=utf-8",
 						cache: false,
-						data: { sBouquetRef: bref, sRef: sref, newName: newname, sRefBefore: dstref }, 
+						data: { sBouquetRef: bref, sRef: sref, newName: newname, sRefBefore: dstref },
 						success: function ( data ) {
 							var r = data.Result;
 							if (r.length == 2) {
@@ -631,10 +647,10 @@
 			},
 
 			// Callback function for search box in left pane
-			// Filters matching services in channels list. 
+			// Filters matching services in channels list.
 			searchChannel: function (txt) {
 				var t = txt.toLowerCase();
-				
+
 				self.filterChannelsCache = [];
 				$.each( self.allChannelsCache, function ( key, val ) {
 					var name = val['servicename'];
@@ -644,7 +660,7 @@
 							servicereference:val['servicereference']
 						});
 				});
-				
+
 				self.fillChannels(self.showChannels);
 				self.setChannelButtons();
 			},
@@ -655,7 +671,7 @@
 			showError: function (txt, st) {
 				st = typeof st !== 'undefined' ? st : 'False';
 				$('#statustext').text('');
-			
+
 				if (st === true || st === 'True' || st === 'true') {
 					$('#statusbox').removeClass('ui-state-error').addClass('ui-state-highlight');
 					$('#statusicon').removeClass('ui-icon-alert').addClass('ui-icon-info');
@@ -664,7 +680,7 @@
 					$('#statusicon').removeClass('ui-icon-info').addClass('ui-icon-alert');
 				}
 				$('#statustext').text(txt);
-			
+
 				if (txt !== '') {
 					$('#statuscont').show();
 				} else {
@@ -680,8 +696,9 @@
 					$.ajax({
 						url: '/bouqueteditor/api/backup',
 						dataType: 'json',
+		                contentType: "application/json; charset=utf-8",
 						cache: false,
-						data: { Filename: fn }, 
+						data: { Filename: fn },
 						success: function ( data ) {
 							var r = data.Result;
 							if (r[0] === false) {
@@ -710,10 +727,10 @@
 				if (confirm(tstr_bqe_restore_question + ' ( ' + fn + ') ?') === false) {
 					return;
 				}
-	
+
 				$('form#uploadrestore')
 					.unbind('submit')
-					.submit(function (e) 
+					.submit(function (e)
 				{
 					var formData = new FormData(this);
 					$.ajax({
@@ -725,6 +742,7 @@
 						cache: false,
 						processData:false,
 						dataType: 'json',
+		                contentType: "application/json; charset=utf-8",
 						success: function (data, textStatus, jqXHR) {
 							var r = data.Result;
 							if (r[0]) {
@@ -751,6 +769,7 @@
 					$.ajax({
 						url: '/bouqueteditor/api/restore',
 						dataType: 'json',
+		                contentType: "application/json; charset=utf-8",
 						cache: false,
 						data: { Filename: fn }, 
 						success: function ( data ) {

--- a/sourcefiles/js/epgr.js
+++ b/sourcefiles/js/epgr.js
@@ -86,7 +86,7 @@ function isAlter(sref) {return (sref.indexOf("1:134:1") == 0);}
 				$.ajax({
 					type: "GET", url: "/epgrefresh",
 					dataType: "xml",
-		            contentType: "application/xml; charset=utf-8",
+					contentType: "application/xml; charset=utf-8",
 					success: function (xml)
 					{
 						self.readEPGR2(xml);
@@ -105,7 +105,7 @@ function isAlter(sref) {return (sref.indexOf("1:134:1") == 0);}
 				$.ajax({
 					type: "GET", url: "/epgrefresh/get",
 					dataType: "xml",
-		            contentType: "application/xml; charset=utf-8",
+					contentType: "application/xml; charset=utf-8",
 					success: function (xml)
 					{
 						var settings = [];
@@ -243,7 +243,7 @@ function isAlter(sref) {return (sref.indexOf("1:134:1") == 0);}
 				$.ajax({
 					type: "GET", url: reqs,
 					dataType: "xml",
-		            contentType: "application/xml; charset=utf-8",
+					contentType: "application/xml; charset=utf-8",
 					success: function (xml)
 					{
 						var state=$(xml).find("e2state").first();
@@ -293,7 +293,7 @@ function isAlter(sref) {return (sref.indexOf("1:134:1") == 0);}
 				$.ajax({
 					type: "GET", url: reqss,
 					dataType: "xml",
-		            contentType: "application/xml; charset=utf-8",
+					contentType: "application/xml; charset=utf-8",
 					success: function (xml)
 					{
 						var state=$(xml).find("e2state").first();
@@ -310,7 +310,7 @@ function isAlter(sref) {return (sref.indexOf("1:134:1") == 0);}
 				$.ajax({
 					type: "GET", url: "/epgrefresh/refresh",
 					dataType: "xml",
-		            contentType: "application/xml; charset=utf-8",
+					contentType: "application/xml; charset=utf-8",
 					success: function (xml)
 					{
 						var state=$(xml).find("e2state").first();

--- a/sourcefiles/js/epgr.js
+++ b/sourcefiles/js/epgr.js
@@ -86,6 +86,7 @@ function isAlter(sref) {return (sref.indexOf("1:134:1") == 0);}
 				$.ajax({
 					type: "GET", url: "/epgrefresh",
 					dataType: "xml",
+		            contentType: "application/xml; charset=utf-8",
 					success: function (xml)
 					{
 						self.readEPGR2(xml);
@@ -104,6 +105,7 @@ function isAlter(sref) {return (sref.indexOf("1:134:1") == 0);}
 				$.ajax({
 					type: "GET", url: "/epgrefresh/get",
 					dataType: "xml",
+		            contentType: "application/xml; charset=utf-8",
 					success: function (xml)
 					{
 						var settings = [];
@@ -241,6 +243,7 @@ function isAlter(sref) {return (sref.indexOf("1:134:1") == 0);}
 				$.ajax({
 					type: "GET", url: reqs,
 					dataType: "xml",
+		            contentType: "application/xml; charset=utf-8",
 					success: function (xml)
 					{
 						var state=$(xml).find("e2state").first();
@@ -290,6 +293,7 @@ function isAlter(sref) {return (sref.indexOf("1:134:1") == 0);}
 				$.ajax({
 					type: "GET", url: reqss,
 					dataType: "xml",
+		            contentType: "application/xml; charset=utf-8",
 					success: function (xml)
 					{
 						var state=$(xml).find("e2state").first();
@@ -306,6 +310,7 @@ function isAlter(sref) {return (sref.indexOf("1:134:1") == 0);}
 				$.ajax({
 					type: "GET", url: "/epgrefresh/refresh",
 					dataType: "xml",
+		            contentType: "application/xml; charset=utf-8",
 					success: function (xml)
 					{
 						var state=$(xml).find("e2state").first();

--- a/sourcefiles/js/openwebif.js
+++ b/sourcefiles/js/openwebif.js
@@ -555,6 +555,7 @@ function addEditTimerEvent(sRef, eventId) {
 	$.ajax({
 		url: url,
 		dataType: "json",
+		contentType: "application/json; charset=utf-8",
 		success: function(result) { 
 			if (typeof result !== 'undefined' && typeof result.event !== 'undefined') {
 				addTimer(result.event);
@@ -599,6 +600,7 @@ function delTimerEvent(sRef,eventId) {
 	$.ajax({
 		url: url,
 		dataType: "json",
+		contentType: "application/json; charset=utf-8",
 		success: function(result) { 
 			if (typeof result !== 'undefined' && typeof result.event !== 'undefined') {
 				// FIXME : this will not work if the timer is modified
@@ -626,6 +628,7 @@ function toggleTimerStatus(sRef, begin, end) {
 	$.ajax({
 		url: url,
 		dataType: "json",
+		contentType: "application/json; charset=utf-8",
 		data:data,
 		success: function(result) { 
 			
@@ -749,6 +752,7 @@ function getStatusInfo() {
 	$.ajax({
 		url: '/api/statusinfo',
 		dataType: "json",
+		contentType: "application/json; charset=utf-8",
 		cache: false,
 		success: function(statusinfo) { 
 		// Set Volume
@@ -822,6 +826,7 @@ function getMessageAnswer() {
 	$.ajax({
 		url: '/api/messageanswer',
 		dataType: "json",
+		contentType: "application/json; charset=utf-8",
 		cache: false,
 		success: function(result) { 
 			$('#messageSentResponse').html(result['message']);
@@ -849,6 +854,7 @@ function sendMessage() {
 	$.ajax({
 		url: '/api/message?text=' + text + '&type=' + type + '&timeout=' + timeout,
 		dataType: "json",
+		contentType: "application/json; charset=utf-8",
 		cache: false,
 		success: function(result) { 
 			$('#messageSentResponse').html(result['message']);


### PR DESCRIPTION
This makes it easier for viewing reponses, and gives an indicator to the calling service, as to the content type of the body.

E.g. calling an API today using PostMan shows this:
![screen shot 2017-01-26 at 14 29 46](https://cloud.githubusercontent.com/assets/254309/22334883/464b1e1e-e3d4-11e6-8cde-1a7035af4294.png)

With this fix, the client will render the response automatically as JSON or XML where appropriate.

![screen shot 2017-01-26 at 14 29 59](https://cloud.githubusercontent.com/assets/254309/22334909/643f631c-e3d4-11e6-98b6-1cc329e26123.png)
