### PR TITLE
Scale Correctly the SNR/AGC values

### DIFF
--- a/plugin/controllers/models/info.py
+++ b/plugin/controllers/models/info.py
@@ -606,17 +606,17 @@ def getFrontendStatus(session):
 	if frontendStatus is not None:
 		percent = frontendStatus.get("tuner_signal_quality")
 		if percent is not None:
-			inf['snr'] = int(percent * 100 / 65536)
+			inf['snr'] = int(percent * 100 / 65535)
 			inf['snr_db'] = inf['snr']
 		percent = frontendStatus.get("tuner_signal_quality_db")
 		if percent is not None:
 			inf['snr_db'] = "%3.02f" % (percent / 100.0)
 		percent = frontendStatus.get("tuner_signal_power")
 		if percent is not None:
-			inf['agc'] = int(percent * 100 / 65536)
+			inf['agc'] = int(percent * 100 / 65535)
 		percent =  frontendStatus.get("tuner_bit_error_rate")
 		if percent is not None:
-			inf['ber'] = int(percent * 100 / 65536)
+			inf['ber'] = int(percent * 100 / 65535)
 
 	return inf
 

--- a/plugin/controllers/models/services.py
+++ b/plugin/controllers/models/services.py
@@ -168,17 +168,17 @@ def getCurrentFullInfo(session):
 	if frontendStatus is not None:
 		percent = frontendStatus.get("tuner_signal_quality")
 		if percent is not None:
-			inf['snr'] = int(percent * 100 / 65536)
+			inf['snr'] = int(percent * 100 / 65535)
 			inf['snr_db'] = inf['snr']
 		percent = frontendStatus.get("tuner_signal_quality_db")
 		if percent is not None:
 			inf['snr_db'] = "%3.02f dB" % (percent / 100.0)
 		percent = frontendStatus.get("tuner_signal_power")
 		if percent is not None:
-			inf['agc'] = int(percent * 100 / 65536)
+			inf['agc'] = int(percent * 100 / 65535)
 		percent =  frontendStatus.get("tuner_bit_error_rate")
 		if percent is not None:
-			inf['ber'] = int(percent * 100 / 65536)
+			inf['ber'] = int(percent * 100 / 65535)
 	else:
 		inf['snr'] = 0
 		inf['snr_db'] = inf['snr']


### PR DESCRIPTION
According to the documentation the drivers return a value from 0 to 0xffff (100%).

https://linuxtv.org/downloads/v4l-dvb-apis/uapi/dvb/frontend-stat-properties.html

In some places we are using 65536 (0x10000) instead of 65535 (0xffff).
That was causing the maximum value to displayed as 99% instead of 100%.

Replace the 65536 with 65535 in frontend CNR/SNR calculatiosn to fix issue.

Following changes in: https://github.com/OpenPLi/enigma2/pull/656