### PR TITLE
grab: use anchor with timestamp to force grab refesh

### DIFF
--- a/sourcefiles/js/openwebif.js
+++ b/sourcefiles/js/openwebif.js
@@ -815,10 +815,11 @@ function grabScreenshot(mode) {
 	} else {
 		mode = screenshotMode;
 	}
+	timestamp = new Date().getTime();
 	if (GetLSValue('ssr_hd',false)){
-		$('#screenshotimage').attr("src",'/grab?format=jpg&mode=' + mode);
+		$('#screenshotimage').attr("src",'/grab?format=jpg&mode=' + mode + '#' + timestamp);
 	} else {
-		$('#screenshotimage').attr("src",'/grab?format=jpg&r=720&mode=' + mode);
+		$('#screenshotimage').attr("src",'/grab?format=jpg&r=720&mode=' + mode + '#' + timestamp);
 	}
 	$('#screenshotimage').attr("width",720);
 }


### PR DESCRIPTION
It seems after https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/commit/1b697fca76a9fb935082a54b687b466a3d4afbe4
we are having issues refreshing grab although proper 'do not cache' implemented in https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/commit/89ae4be2679ebb4b9cdd068a6426483fc565d316

More info about pros and cons of every method here: http://stackoverflow.com/questions/1077041/refresh-image-with-a-new-one-at-the-same-url/22429796#22429796