### PR TITLE
[servicelist.py] Bug fix in reloadServicesLists()

### DIFF
--- a/plugin/controllers/models/servicelist.py
+++ b/plugin/controllers/models/servicelist.py
@@ -25,6 +25,17 @@ def reloadTransponders(self):
 def reloadParentalControl(self):
 	Components.ParentalControl.parentalControl.open()
 
+def clearAllServices(self):
+	satList = []
+	satellites = {}
+	transponders = {}
+	self.eDVBDB.readSatellites(satList, satellites, transponders)
+	positions = [x[0] for x in satList] 
+	for pos in positions: # sat
+		self.eDVBDB.removeServices(-1, -1, -1, pos)
+	self.eDVBDB.removeServices(0xFFFF0000 - 0x100000000) # cable
+	self.eDVBDB.removeServices(0xEEEE0000 - 0x100000000) # terrestrial
+
 def reloadServicesLists(self, request):
 	self.eDVBDB = eDVBDB.getInstance()
 	res = "False"
@@ -36,11 +47,13 @@ def reloadServicesLists(self, request):
 		mode = ""
 
 	if mode == "0":
+		clearAllServices(self)
 		reloadLameDB(self)
 		reloadUserBouquets(self)
 		res = True
 		msg = "reloaded both"
 	elif mode == "1":
+		clearAllServices(self)
 		reloadLameDB(self)
 		res = True
 		msg = "reloaded lamedb"


### PR DESCRIPTION
[servicelist.py] Bug fix in reloadServicesLists()

Recreate bug as follows:

1) Retrieve lamedb from STB over FTP.
2) Manually edit a channel name.
3) Send lamedb to STB over FTP.
4) Call http://<STB-IP>/web/servicelistreload?mode=0
5) Check channel name.

In the case of the current code the service name does not change.
This makes it impossible to correctly reload service lists.
Only way to get clean reload with current code is to put the STB to sleep (init 4).

The code in this commit cleans enigma2 before the reload so the new service list will not be contaminated by the current one loaded in the RAM.