### PR TITLE
Feature unquote fix and json output improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.swp
 *.ipk
 /.idea
+*~

--- a/plugin/controllers/file.py
+++ b/plugin/controllers/file.py
@@ -99,5 +99,5 @@ class FileController(resource.Resource):
 				data.append({"result": True,"dirs": directories,"files": files})
 			else:
 				data.append({"result": False,"message": "path %s not exits" % (path)})
-			request.setHeader("content-type", "application/json")
-			return json.dumps(data)
+			request.setHeader("content-type", "application/json; charset=utf-8")
+			return json.dumps(data, indent=2)

--- a/plugin/controllers/file.py
+++ b/plugin/controllers/file.py
@@ -12,7 +12,7 @@
 import os
 import re
 import glob
-from urllib import unquote, quote
+from urllib import quote
 import json
 
 from twisted.web import static, resource, http
@@ -42,7 +42,7 @@ class FileController(resource.Resource):
 			action = request.args["action"][0]
 
 		if "file" in request.args:
-			filename = unquote(request.args["file"][0]).decode('utf-8', 'ignore').encode('utf-8')
+			filename = request.args["file"][0].decode('utf-8', 'ignore').encode('utf-8')
 			filename = re.sub("^/+", "/", os.path.realpath(filename))
 
 			if not os.path.exists(filename):


### PR DESCRIPTION
- fix: HTTP Request parameters are already unquoted by the twisted framework (see twisted.web.http.Request.requestReceived; e.g. ``self.args = parse_qs(argstring, 1)``)

- add charset=utf-8 to content header for JSON encoded output, add indentation for improved readability
