### PR TITLE
Add support for /media/mmc/picon/ f.e. Zgemma H5 series microSD card …

### DIFF
--- a/plugin/controllers/models/info.py
+++ b/plugin/controllers/models/info.py
@@ -194,6 +194,8 @@ def getPiconPath():
 		return "/media/cf/picon/"
 	elif pathExists("/media/hdd/picon/"):
 		return "/media/hdd/picon/"
+	elif pathExists("/media/mmc/picon/"):
+		return "/media/mmc/picon/"
 	elif pathExists("/usr/share/enigma2/picon/"):
 		return "/usr/share/enigma2/picon/"
 	elif pathExists("/picon/"):


### PR DESCRIPTION
Hi,

Zgemma H5 series have an internal microSD card reader mounted as /media/mmc/ so it is a place to store picon on those boxes, so I add the path /media/mmc/picon/  .

Pr2