### PR TITLE
Feature rest improvements

### DIFF
--- a/plugin/controllers/file.py
+++ b/plugin/controllers/file.py
@@ -101,6 +101,6 @@ class FileController(resource.Resource):
 						files.remove(x)
 				if nofiles:
 					files = []
-				return json.dumps({"Result": True,"dirs": directories,"files": files}, indent=2)
+				return json.dumps({"result": True,"dirs": directories,"files": files}, indent=2)
 			else:
-				return json.dumps({"Result": False,"message": "path %s not exits" % (path)}, indent=2)
+				return json.dumps({"result": False,"message": "path %s not exits" % (path)}, indent=2)

--- a/plugin/controllers/rest_fs_access.py
+++ b/plugin/controllers/rest_fs_access.py
@@ -181,7 +181,6 @@ class FileController(twisted.web.resource.Resource):
 				"path": request.path,
 				"uri": request.uri,
 				"method": request.method,
-				"postpath": request.postpath,
 				"file_path": file_path,
 			},
 			"result": False,
@@ -288,14 +287,11 @@ class FileController(twisted.web.resource.Resource):
 		Returns:
 			HTTP response with headers
 		"""
-		response_data = self.get_response_data_template(request)
-		response_data.update(
-			{
-				'result': True,
-				'dirs': [],
-				'files': [],
-			}
-		)
+		response_data = {
+			'result': True,
+			'dirs': [],
+			'files': [],
+		}
 
 		generator = None
 		if "pattern" in request.args:
@@ -420,13 +416,10 @@ class FileController(twisted.web.resource.Resource):
 				request, response_code=http.INTERNAL_SERVER_ERROR,
 				message=exc.message)
 
-		response_data = self.get_response_data_template(request)
-		response_data.update(
-			{
-				'result': True,
-				'filename': target_filename,
-			}
-		)
+		response_data = {
+			'result': True,
+			'filename': target_filename,
+		}
 
 		return self._json_response(request, response_data)
 
@@ -476,7 +469,7 @@ class FileController(twisted.web.resource.Resource):
 				return self.error_response(request,
 										   response_code=http.FORBIDDEN)
 
-		response_data = self.get_response_data_template(request)
+		response_data = {'result': False}
 		try:
 			response_data['result'] = True
 			if self._do_delete:

--- a/plugin/controllers/rest_fs_access.py
+++ b/plugin/controllers/rest_fs_access.py
@@ -38,6 +38,64 @@ Create example file 'test.dat' using HTTP POST request on /file
 
     curl --noproxy localhost -iv -X POST http://localhost:18888/file?filename=test.dat -F "data=blabla"
 
+Request file '/etc/sysctl.conf' (compressed)
+
+    curl --compressed -H "Accept-Encoding: gzip" --noproxy localhost -I http://localhost/file/etc/sysctl.conf
+
+Example Response:
+
+	HTTP/1.1 200 OK
+	Content-Encoding: gzip
+	Accept-Ranges: bytes
+	Expires: Fri, 27 Oct 2017 17:24:11 GMT
+	Server: TwistedWeb/16.2.0
+	Last-Modified: Thu, 01 Jan 1970 00:05:52 GMT
+	Cache-Control: public
+	Date: Wed, 27 Sep 2017 17:24:11 GMT
+	Access-Control-Allow-Origin: *
+	Content-Type: text/plain
+	Set-Cookie: TWISTED_SESSION=7aa774819460330851b703cb3d82b240; Path=/
+
+Request file '/etc/sysctl.conf' (without compression)
+
+	curl --noproxy localhost -I http://localhost/file/etc/sysctl.conf
+
+Example Response:
+
+	HTTP/1.1 200 OK
+	Content-Length: 2065
+	Accept-Ranges: bytes
+	Expires: Fri, 27 Oct 2017 17:26:05 GMT
+	Server: TwistedWeb/16.2.0
+	Last-Modified: Thu, 01 Jan 1970 00:05:52 GMT
+	Cache-Control: public
+	Date: Wed, 27 Sep 2017 17:26:05 GMT
+	Access-Control-Allow-Origin: *
+	Content-Type: text/plain
+	Set-Cookie: TWISTED_SESSION=0b3688af9874df9b432f09bedae63c40; Path=/
+
+Create example file 'test_01.ts' using HTTP POST request on /file. After that
+request 'test_01.ts' compressed. Because of the file extension the server will
+_not_ return its content gzip encoded and orders the client not to cache the
+result.
+
+	curl --noproxy localhost -iv -X POST http://localhost/file/tmp?filename=test_01.ts -F "data=dummy"
+	curl --compressed -H "Accept-Encoding: gzip" --noproxy localhost -I http://localhost/file/tmp/test_01.ts
+
+Example response:
+
+	HTTP/1.1 200 OK
+	Content-Length: 5
+	Accept-Ranges: bytes
+	Expires: -1
+	Server: TwistedWeb/16.2.0
+	Last-Modified: Wed, 27 Sep 2017 17:33:08 GMT
+	Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0, max-age=0
+	Date: Wed, 27 Sep 2017 17:33:19 GMT
+	Access-Control-Allow-Origin: *
+	Content-Type: video/MP2T
+	Set-Cookie: TWISTED_SESSION=7d3e06aa234b04e1124d4812c80dad22; Path=/
+
 """
 import os
 import json
@@ -351,6 +409,7 @@ class FileController(twisted.web.resource.Resource):
 		if path.lower().endswith('.ts'):
 			expires = False
 		self._cache(request, expires=expires)
+
 		return result.render(request)
 
 	def render_GET(self, request):

--- a/plugin/controllers/root.py
+++ b/plugin/controllers/root.py
@@ -11,7 +11,6 @@
 import os
 
 from twisted.web import static, http, proxy
-from twisted.web.server import GzipEncoderFactory
 from twisted.web.resource import EncodingResourceWrapper
 
 from models.info import getPublicPath, getPiconPath
@@ -39,15 +38,21 @@ class RootController(BaseController):
 		self.putChild("web", WebController(session))
 		self.putChild("api", ApiController(session))
 		self.putChild("ajax", AjaxController(session))
+
+		encoder_factory = rest_fs_access.ExtGzipEncoderFactory(
+			extensions=[
+				'txt', 'json', 'html', 'xml', 'js',
+				'eit', 'sc'
+			])
 		#: gzip compression enabled file controller
-		gzip_wrapped_fs_controller = EncodingResourceWrapper(
+		wrapped_fs_controller = EncodingResourceWrapper(
 			rest_fs_access.FileController(
 				root='/',
 				resource_prefix="/file",
 				session=session),
-			[GzipEncoderFactory()]
+			[encoder_factory]
 		)
-		self.putChild("file", gzip_wrapped_fs_controller)
+		self.putChild("file", wrapped_fs_controller)
 		self.putChild("grab", grabScreenshot(session))
 		if os.path.exists(getPublicPath('mobile')):
 			self.putChild("mobile", MobileController(session))

--- a/plugin/controllers/root.py
+++ b/plugin/controllers/root.py
@@ -42,7 +42,7 @@ class RootController(BaseController):
 		encoder_factory = rest_fs_access.ExtGzipEncoderFactory(
 			extensions=[
 				'txt', 'json', 'html', 'xml', 'js',
-				'eit', 'sc'
+				'eit', 'sc', 'ap'
 			])
 		#: gzip compression enabled file controller
 		wrapped_fs_controller = EncodingResourceWrapper(

--- a/plugin/controllers/root.py
+++ b/plugin/controllers/root.py
@@ -39,9 +39,9 @@ class RootController(BaseController):
 		self.putChild("api", ApiController(session))
 		self.putChild("ajax", AjaxController(session))
 
-		encoder_factory = rest_fs_access.ExtGzipEncoderFactory(
+		encoder_factory = rest_fs_access.GzipEncodeByFileExtensionFactory(
 			extensions=[
-				'txt', 'json', 'html', 'xml', 'js',
+				'txt', 'json', 'html', 'xml', 'js', 'conf', 'cfg',
 				'eit', 'sc', 'ap'
 			])
 		#: gzip compression enabled file controller

--- a/testsuite/status_quo_file_controller.py
+++ b/testsuite/status_quo_file_controller.py
@@ -83,7 +83,7 @@ class TestEnigma2FileAPICalls(unittest.TestCase):
 		print("Tried to fetch {!r}".format(req.url))
 		minimal_expectation = {"message": "path {:s} not exits".format(randy),
 							   "result": False}
-		result = req.json()[0]
+		result = req.json()
 		for key in minimal_expectation:
 			self.assertEquals(minimal_expectation[key], result.get(key))
 		self.assertEqual(200, req.status_code)
@@ -97,7 +97,7 @@ class TestEnigma2FileAPICalls(unittest.TestCase):
 		req = requests.get(self.file_url, params=params)
 		print("Tried to fetch {!r}".format(req.url))
 		minimal_expectation = {"dirs": [], "result": True}
-		result = req.json()[0]
+		result = req.json()
 		for key in minimal_expectation:
 			self.assertEquals(minimal_expectation[key], result.get(key))
 		self.assertEqual(200, req.status_code)
@@ -111,7 +111,7 @@ class TestEnigma2FileAPICalls(unittest.TestCase):
 		print("Tried to fetch {!r}".format(req.url))
 		minimal_expectation = {"dirs": ['/etc/opkg/'], "result": True,
 							   "files": []}
-		result = req.json()[0]
+		result = req.json()
 		for key in minimal_expectation:
 			self.assertEquals(minimal_expectation[key], result.get(key))
 		self.assertEqual(200, req.status_code)


### PR DESCRIPTION
- Last changeset contained a bug which led to gzip compression (if requested by client) for all files. Now e.g. `.ts` files will be excluded from compression attempts. 
Currently files with the extensions `['txt', 'json', 'html', 'xml', 'js', 'conf', 'cfg', 'eit', 'sc', 'ap']` will be compressed if client requests this behaviour
- Add content expiration HTTP headers (hardcoded default: content expires after roughly a month)