### PR TITLE
Add proper Content-Type header for API responses

### DIFF
--- a/plugin/controllers/api.py
+++ b/plugin/controllers/api.py
@@ -7,4 +7,5 @@ class ApiController(WebController):
 		WebController.__init__(self, session, path)
 
 	def prePageLoad(self, request):
+		request.setHeader("content-type", "application/json")
 		self.isJson = True


### PR DESCRIPTION
Hello,

if I'm not mistaken the /web API endpoints return XML and send the text/xml header.
Similarly the /api API endpoints do just the same as their /web pendants, but return the response in JSON format.
However the /api endpoints do not set a special header and thus send the default Twisted text/html header.

Could you please just add the additional header to the /api endpoints as well.
The above one-liner fix should do the trick if I'm not mistaken.