### PR TITLE
too long text on a button

### DIFF
--- a/locale/sk.po
+++ b/locale/sk.po
@@ -1305,7 +1305,7 @@ msgstr "Pohotovostný režim"
 
 #: plugin/local.py:194
 msgid "Standby Toggle"
-msgstr "Prepnúť z/do pohotov. režimu"
+msgstr "Prepnúť pohotov.režim"
 
 #: plugin/local.py:195
 msgid "Start time is after end time"


### PR DESCRIPTION
Compress text on a button. Unfortunately, the size of the button does not allow you to insert too long text.

It may be appropriate to adjust the style of the buttons - to increase their width.
https://www.imgup.cz/images/2018/01/20/image0001.png