### PR TITLE
Fix crash when key is not found in section_config

### DIFF
--- a/plugin/controllers/models/config.py
+++ b/plugin/controllers/models/config.py
@@ -198,7 +198,6 @@ def getConfigs(key):
 	if key in configfiles.section_config:
 		config_entries = configfiles.section_config[key][1]
 		title = configfiles.section_config[key][0]
-	if config_entries:
 		for entry in config_entries:
 			try:
 				data = getJsonFromConfig(eval(entry.text or ""))  # nosec


### PR DESCRIPTION
Fixes the following crash:

Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/twisted/protocols/basic.py", line 571, in dataReceived

  File "/usr/lib/python2.7/site-packages/twisted/web/http.py", line 1752, in lineReceived

  File "/usr/lib/python2.7/site-packages/twisted/web/http.py", line 1845, in allContentReceived

  File "/usr/lib/python2.7/site-packages/twisted/web/http.py", line 766, in requestReceived

--- <exception caught here> ---
  File "/usr/lib/python2.7/site-packages/twisted/web/server.py", line 190, in process

  File "/usr/lib/python2.7/site-packages/twisted/web/server.py", line 241, in render

  File "/DATA/Beyonwiz/17.5/builds/beyonwiz/release/inihdp/tmp/work/all-oe-linux/enigma2-plugin-extensions-openwebif/1.2+gitAUTOINC+7bfbaaee78-r0/git/plugin/controllers/base.py", line 140, in render

  File "/DATA/Beyonwiz/17.5/builds/beyonwiz/release/inihdp/tmp/work/all-oe-linux/enigma2-plugin-extensions-openwebif/1.2+gitAUTOINC+7bfbaaee78-r0/git/plugin/controllers/ajax.py", line 212, in P_config

  File "/DATA/Beyonwiz/17.5/builds/beyonwiz/release/inihdp/tmp/work/all-oe-linux/enigma2-plugin-extensions-openwebif/1.2+gitAUTOINC+7bfbaaee78-r0/git/plugin/controllers/models/config.py", line 201, in getConfigs

exceptions.UnboundLocalError: local variable 'config_entries' referenced before assignment