### PR TITLE
local.py: Fix BSoD

### DIFF
--- a/plugin/local.py
+++ b/plugin/local.py
@@ -6,9 +6,7 @@ from Components.config import config
 
 try:
 	AT_unit = config.plugins.autotimer.unit.value == "hour" and _("hour") or _("minute")
-except NameError:
-	AT_unit = "hour"
-except KeyError:
+except:
 	AT_unit = "hour"
 
 tstrings = {


### PR DESCRIPTION
This code is here for images like OpenPLi that do not support config.plugins.autotimer.unit