### PR TITLE
[transcoding.py] Make the code more resilient

### DIFF
--- a/plugin/controllers/transcoding.py
+++ b/plugin/controllers/transcoding.py
@@ -35,13 +35,13 @@ def get_transcoding_features(encoder = 0):
 			if hasattr(config.plugins.transcodingsetup, feature):
 				try:
 					encoder_features[feature] = getattr(config.plugins.transcodingsetup, feature)
-				except KeyError:
+				except:
 					pass
 		else:
 			if hasattr(config.plugins.transcodingsetup, "%s_%s" % (feature, encoder)):
 				try:
 					encoder_features[feature] = getattr(config.plugins.transcodingsetup, "%s_%s" % (feature, encoder))
-				except KeyError:
+				except:
 					pass
 	return encoder_features
 
@@ -52,7 +52,7 @@ class TranscodingController(resource.Resource):
 		request.setHeader('charset', 'UTF-8')
 		try:
 			port = config.plugins.transcodingsetup.port
-		except KeyError:
+		except:
 			return '<?xml version="1.0" encoding="UTF-8" ?><e2simplexmlresult><e2state>false</e2state><e2statetext>Transcoding Plugin is not installed or your STB does not support transcoding</e2statetext></e2simplexmlresult>'
 
 		encoders = (0, 1)


### PR DESCRIPTION
Protect the getattr() code calls from crashing if the getattr() call get either a KeyError (from the broken version of config.py) or AttributeError (from the fixed version of config.py).  The more general `except` makes the code less vulnerable.

Protect the code from crashing if `config.plugins.transcodingsetup.port` returns ANY error.

This change will resolve issues with the corrected config.py in OpenPLi, OpenViX and Beyonwiz while still working with builds that don't use the fixed version.
