### PR TITLE
[wol.py] Make the code more resilient

### DIFF
--- a/plugin/controllers/wol.py
+++ b/plugin/controllers/wol.py
@@ -24,7 +24,7 @@ class WOLSetupController(resource.Resource):
 		try:
 			wol_active = config.plugins.wolconfig.activate.value
 			wol_location = config.plugins.wolconfig.location.value
-		except KeyError:
+		except:
 			return '<?xml version="1.0" encoding="UTF-8" ?><e2simplexmlresult><e2state>false</e2state><e2statetext>WOLSetup plugin is not installed or your STB does not support WOL</e2statetext></e2simplexmlresult>'
 
 		if len(request.args):


### PR DESCRIPTION
Protect the code from crashing if `config.plugins.wolconfig.activate` or `config.plugins.wolconfig.location` return ANY errors.

This change will resolve issues with the corrected config.py in OpenPLi, OpenViX and Beyonwiz while still working with builds that don't use the fixed version.
