### PR TITLE
new XMLTV export for epg data

### DIFF
--- a/plugin/controllers/models/config.py
+++ b/plugin/controllers/models/config.py
@@ -8,6 +8,8 @@ import xml.etree.cElementTree  # nosec
 
 from ..i18n import _
 from ..utilities import get_config_attribute
+from datetime import datetime
+import time
 
 def addCollapsedMenu(name):
 	tags = config.OpenWebif.webcache.collapsedmenus.value.split("|")
@@ -215,6 +217,18 @@ def getSettings():
 	return {
 		"result": True,
 		"settings": configkeyval
+	}
+	
+def getUtcOffset():
+	now = time.time()
+	offset = (datetime.fromtimestamp(now) - 
+			datetime.utcfromtimestamp(now)).total_seconds()			
+	hours = round(offset / 3600)
+	minutes = (offset - (hours * 3600))
+	return {
+		"result": True,
+		#round minutes to next quarter hour
+		"utcoffset": "{:+05}".format(int(hours * 100 + (round(minutes / 900) * 900 / 60)))
 	}
 
 class ConfigFiles:

--- a/plugin/controllers/views/web/epgxmltv.tmpl
+++ b/plugin/controllers/views/web/epgxmltv.tmpl
@@ -1,0 +1,18 @@
+#filter WebSafe
+#from datetime import datetime
+<?xml version="1.0" encoding="UTF-8"?>
+<tv source-info-url="https://github.com/E2OpenPlugins/e2openplugin-OpenWebif" source-info-name="OpenWebif">
+	#for $service in $services
+	<channel id="$service.servicereference">
+		<display-name>$service.servicename</display-name>			
+	</channel>
+	#end for	
+	#for $event in $events
+	<programme start="$datetime.utcfromtimestamp($event.begin_timestamp).strftime('%Y%m%d%H%M%S') $offset.utcoffset" stop="$datetime.utcfromtimestamp($event.begin_timestamp + $event.duration_sec).strftime('%Y%m%d%H%M%S') $offset.utcoffset" channel="$event.sref">
+		<title lang="$lang">$str($event.title)</title>
+		<sub-title lang="$lang">$str($event.shortdesc)</sub-title>
+		<desc lang="$lang">$str($event.longdesc)</desc>		
+	</programme>
+	#end for	
+</tv>
+#end filter

--- a/plugin/controllers/web.py
+++ b/plugin/controllers/web.py
@@ -19,7 +19,7 @@ from models.locations import getLocations, getCurrentLocation, addLocation, remo
 from models.timers import getTimers, addTimer, addTimerByEventId, editTimer, removeTimer, toggleTimerStatus, cleanupTimer, writeTimerList, recordNow, tvbrowser, getSleepTimer, setSleepTimer, getPowerTimer, setPowerTimer, getVPSChannels
 from models.message import sendMessage, getMessageAnswer
 from models.movies import getMovieList, removeMovie, getMovieTags, moveMovie, renameMovie, getAllMovies
-from models.config import getSettings, addCollapsedMenu, removeCollapsedMenu, saveConfig, getConfigs, getConfigsSections
+from models.config import getSettings, addCollapsedMenu, removeCollapsedMenu, saveConfig, getConfigs, getConfigsSections, getUtcOffset
 from models.stream import getStream, getTS, getStreamSubservices, GetSession
 from models.servicelist import reloadServicesLists
 from models.mediaplayer import mediaPlayerAdd, mediaPlayerRemove, mediaPlayerPlay, mediaPlayerCommand, mediaPlayerCurrent, mediaPlayerList, mediaPlayerLoad, mediaPlayerSave, mediaPlayerFindFile
@@ -1395,6 +1395,31 @@ class WebController(BaseController):
 			except ValueError:
 				pass
 		return getBouquetEpg(request.args["bRef"][0], begintime, endtime, self.isJson)
+	
+	def P_epgxmltv(self, request):
+		"""
+		Request handler for the `epgxmltv` endpoint.
+	
+		.. note::
+	
+			Not available in *Enigma2 WebInterface API*.
+	
+		Args:
+			request (twisted.web.server.Request): HTTP request object
+			bRef: mandatory, method uses epgmulti
+			lang: mandatory, needed for xmltv and Enigma2 has no parameter for epg language			
+		Returns:
+			HTTP response with headers
+		"""
+		res = self.testMandatoryArguments(request, ["bRef", "lang"])
+		if res:
+			return res
+		ret = self.P_epgmulti(request)
+		bRef = request.args["bRef"][0]
+		ret["services"] = getServices(bRef, True, False)["services"]
+		ret["lang"] = request.args["lang"][0]
+		ret["offset"] = getUtcOffset()
+		return ret
 
 	def P_epgnow(self, request):
 		res = self.testMandatoryArguments(request, ["bRef"])


### PR DESCRIPTION
XMLTV is a normed xml format to transfer channel and epg data (https://en.wikipedia.org/wiki/XMLTV). In case someone needs to use his epg with other devices, XMLTV can help, because there are a few readers for Windows, Android, ... available and more and more enigma-based clients break their epg part up to a paid component.
I've checked the changes with openATV 6.1 as source and KODI as destination for the epg data

Fair warning:
This is my second python code (after a "Hello World"-Tutorial), so someone with more python knowledge should have a look at my changes and check possible exceptions. 
I prefer to learn a language in practice and the XMLTV export is something OpenWebif misses in my eyes