### PR TITLE
Open Vision is PLi based too.

### DIFF
--- a/plugin/controllers/models/owibranding.py
+++ b/plugin/controllers/models/owibranding.py
@@ -681,7 +681,7 @@ def getAllInfo():
 			except:  # nosec  # noqa: E722
 				pass
 
-		if distro in ("openpli", "satdreamgr"):
+		if distro in ("openpli", "satdreamgr", "openvision"):
 			oever = "PLi-OE"
 			try:
 				imagelist = open("/etc/issue").readlines()[-2].split()[1].split('.')

--- a/plugin/controllers/models/stream.py
+++ b/plugin/controllers/models/stream.py
@@ -67,7 +67,7 @@ def getStream(session, request, m3ufile):
 	model = info["model"]
 	machinebuild = info["machinebuild"]
 	urlparam = '?'
-	if info["imagedistro"] in ('openpli', 'satdreamgr'):
+	if info["imagedistro"] in ('openpli', 'satdreamgr', 'openvision'):
 		urlparam = '&'
 	transcoder_port = None
 	args = ""
@@ -167,7 +167,7 @@ def getTS(self, request):
 		transcoder_port = None
 		args = ""
 		urlparam = '?'
-		if info["imagedistro"] in ('openpli'):
+		if info["imagedistro"] in ('openpli', 'satdreamgr', 'openvision'):
 			urlparam = '&'
 		
 		if fileExists("/dev/bcm_enc0"):


### PR DESCRIPTION
See https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/commit/34cef5635480fe4a1fcda5187ed02e02b347dd2a

There was a "satdreamgr" missing in stream.py L170 which I added too.