### PR TITLE
write plugin settings to flash after change

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -22,7 +22,7 @@ from Plugins.Plugin import PluginDescriptor
 from Components.ActionMap import ActionMap
 from Components.Label import Label
 from Components.ConfigList import ConfigListScreen
-from Components.config import config, getConfigListEntry, ConfigSubsection, ConfigInteger, ConfigYesNo, ConfigText, ConfigSelection
+from Components.config import config, getConfigListEntry, ConfigSubsection, ConfigInteger, ConfigYesNo, ConfigText, ConfigSelection, configfile
 from enigma import getDesktop
 from controllers.models.info import getInfo
 from controllers.defaults import getKinopoisk
@@ -186,6 +186,7 @@ class OpenWebifConfig(Screen, ConfigListScreen):
 			HttpdRestart(global_session)
 		else:
 			HttpdStop(global_session)
+		configfile.save()
 		self.close()
 
 	def keyCancel(self):


### PR DESCRIPTION
Some external processes like streamproxy in openpli have a notifiy on the /etc/enigma2/settings because they use the config.OpenWebif.auth and config.OpenWebif.auth_for_streaming values.
With configfile.save()  no GUI restart is neccessary to inform streamproxy about the auth changes

I don´´t know if you like these code change for all images but in openpli it helps to avoid user confusions