### PR TITLE
[stream.py] fix BSOD stop stream

### DIFF
--- a/plugin/controllers/stream.py
+++ b/plugin/controllers/stream.py
@@ -52,7 +52,10 @@ class StreamAdapter:
 		converter_args = []
 		self.converter = Streaming(converter_args)
 		self.converter.source = self
-		self.request.write(self.converter.getText())
+		try:
+			self.request.write(self.converter.getText())
+		except:
+			pass
 
 
 class StreamController(resource.Resource):


### PR DESCRIPTION
Traceback (most recent call last):
  File
"/usr/lib/enigma2/python/Navigation.py", line 78, in
dispatchRecordEvent
  File
"/usr/lib/enigma2/python/Plugins/Extensions/OpenWebif/controllers/stream.py",
line 55, in requestWrite
  File
"/usr/lib/python2.7/site-packages/twisted/web/server.py", line 234, in
write
  File "/usr/lib/python2.7/site-packages/twisted/web/http.py",
line 1086, in write
AttributeError: 'NoneType' object has no attribute
'write'