### PR TITLE
Bug in timers.py addTimerByEventId (repeated should be an integer)

### DIFF
--- a/plugin/controllers/models/timers.py
+++ b/plugin/controllers/models/timers.py
@@ -228,7 +228,7 @@ def addTimerByEventId(session, eventid, serviceref, justplay, dirname, tags, vps
 		AFTEREVENT.AUTO,
 		dirname,
 		tags,
-		False,
+		0,
 		vpsinfo,
 		None,
 		eit,


### PR DESCRIPTION
**Problem**
If using import timer for a fallback tuner. Sometimes it isn't possible to look at the timers. Error message with FallbackTimer.py:64. This also occur while open EPG. This on the client STB.

**Details**
This problem occur if the timer list from the server stb contains invalid data. In this case "<e2repeated>False</e2repeated>". The repeated value is an integer and shouldn't be "False". I got this fault because set timer via the DreamDroid app in Android. A workaround is to restart Enigma, this will cleanup the faulty value in timer list.

**Reproduce**
It is possible to reproduce the core of this fault with only one stb (don't need to run fallback tuner).
1. Have the STB on or in active standby.
2. With a browser goto the OpenWebif of the STB.
3. Click up the EPG for a television channel.
4. Press the icon Add Timer.
5. Goto browser address http://<stb.ip.address>/web/timerlist.
6. This will show the timer list in xml format. Please note the "e2repeated" row for the newly added timer. The value is "False" (invalid value).
7. Restart Enigma2 in the STB.
8. Once again goto the http://<stb.ip.address>/web/timerlist page in the browser.
9. Note that the "e2repeated" row now contains the value "0". Enigma2 have cleanup the timer list.

**Solution**
In the file plugin/controllers/models/timers.py the call to addTimer in addTimerByEventId have a faulty argument (line 231). The repeated argument should be 0, not False.

**Test**
Test have been done with OpenPLi. The file /usr/lib/enigma2/python/Plugins/Extensions/OpenWebif/controllers/models/timers.pyo have been removed and replaced with the new timers.py file. After restart of Enigma step 2-5 above have been executed and the repeated value is now 0 for the newly created timer. Also tested to set a timer via DreamDroid.

**Comments**
It also seems to be another fault in this source file. In setPowerTimer repeated is handle as an boolean. For me the row "repeated = repeated" seems mysterious. I don't have time right now to look into these. Hopefully someone with experiance with this code can look at it.