### PR TITLE
Prevent exception in case iNetwork.getAdapterAttribute() returns "None"

### DIFF
--- a/plugin/controllers/base.py
+++ b/plugin/controllers/base.py
@@ -275,18 +275,19 @@ class BaseController(resource.Resource):
 		ifaces = iNetwork.getConfiguredAdapters()
 		if len(ifaces):
 			ip_list = iNetwork.getAdapterAttribute(ifaces[0], "ip")  # use only the first configured interface
-			ip = "%d.%d.%d.%d" % (ip_list[0], ip_list[1], ip_list[2], ip_list[3])
+			if ip_list:
+				ip = "%d.%d.%d.%d" % (ip_list[0], ip_list[1], ip_list[2], ip_list[3])
 
-			if fileExists(resolveFilename(SCOPE_PLUGINS, "Extensions/LCD4linux/WebSite.pyo")):
-				lcd4linux_key = "lcd4linux/config"
-				if fileExists(resolveFilename(SCOPE_PLUGINS, "Extensions/WebInterface/plugin.pyo")):
-					try:
-						lcd4linux_port = "http://" + ip + ":" + str(config.plugins.Webinterface.http.port.value) + "/"
-						lcd4linux_key = lcd4linux_port + 'lcd4linux/config'
-					except:  # noqa: E722
-						lcd4linux_key = None
-				if lcd4linux_key:
-					extras.append({'key': lcd4linux_key, 'description': _("LCD4Linux Setup"), 'nw': '1'})
+				if fileExists(resolveFilename(SCOPE_PLUGINS, "Extensions/LCD4linux/WebSite.pyo")):
+					lcd4linux_key = "lcd4linux/config"
+					if fileExists(resolveFilename(SCOPE_PLUGINS, "Extensions/WebInterface/plugin.pyo")):
+						try:
+							lcd4linux_port = "http://" + ip + ":" + str(config.plugins.Webinterface.http.port.value) + "/"
+							lcd4linux_key = lcd4linux_port + 'lcd4linux/config'
+						except:  # noqa: E722
+							lcd4linux_key = None
+					if lcd4linux_key:
+						extras.append({'key': lcd4linux_key, 'description': _("LCD4Linux Setup"), 'nw': '1'})
 
 		self.oscamconf = self.oscamconfPath()
 		if self.oscamconf is not None:


### PR DESCRIPTION
We have two reports of crashes when ip_list is used; I've tried to find the reason why iNetwork returns None here, but have no explanation. Technically this patch just pays respect to what iNetwork.getAdapterAttribute() may return, so I'd suggest to merge it.