### PR TITLE
Added support for SSL chains (ignored by

### DIFF
--- a/plugin/httpserver.py
+++ b/plugin/httpserver.py
@@ -209,7 +209,7 @@ def HttpdStart(session):
 					chain = None
 					if os.path.exists(CHAIN_FILE):
 						chain = [crypto.load_certificate(crypto.FILETYPE_PEM, open(CHAIN_FILE, 'rt').read())]
-						vtilog("[OpenWebif] ssl chain file found - loading")
+						print "[OpenWebif] ssl chain file found - loading"
 					context = ssl.CertificateOptions(privateKey=key, certificate=cert, extraCertChain=chain)
 				except:
 					# THIS EXCEPTION IS ONLY CATCHED WHEN CERT FILES ARE BAD (look below for error)

--- a/plugin/httpserver.py
+++ b/plugin/httpserver.py
@@ -205,7 +205,7 @@ def HttpdStart(session):
 				try:
 					key = crypto.load_privatekey(crypto.FILETYPE_PEM, open(KEY_FILE, 'rt').read())
 					cert = crypto.load_certificate(crypto.FILETYPE_PEM, open(CERT_FILE, 'rt').read())
-					vtilog("[OpenWebif] CHAIN_FILE = %s" % CHAIN_FILE)
+					print "[OpenWebif] CHAIN_FILE = %s" % CHAIN_FILE
 					chain = None
 					if os.path.exists(CHAIN_FILE):
 						chain = [crypto.load_certificate(crypto.FILETYPE_PEM, open(CHAIN_FILE, 'rt').read())]

--- a/plugin/httpserver.py
+++ b/plugin/httpserver.py
@@ -20,9 +20,10 @@ from twisted.internet.error import CannotListenError
 from twisted.internet.protocol import Factory, Protocol
 
 from controllers.root import RootController
-from sslcertificate import SSLCertificateGenerator, KEY_FILE, CERT_FILE, CA_FILE
+from sslcertificate import SSLCertificateGenerator, KEY_FILE, CERT_FILE, CA_FILE, CHAIN_FILE
 from socket import has_ipv6
 from OpenSSL import SSL
+from OpenSSL import crypto
 from Components.Network import iNetwork
 
 import os
@@ -202,7 +203,14 @@ def HttpdStart(session):
 			# start https webserver on port configured port
 			try:
 				try:
-					context = ssl.DefaultOpenSSLContextFactory(KEY_FILE, CERT_FILE)
+					key = crypto.load_privatekey(crypto.FILETYPE_PEM, open(KEY_FILE, 'rt').read())
+					cert = crypto.load_certificate(crypto.FILETYPE_PEM, open(CERT_FILE, 'rt').read())
+					vtilog("[OpenWebif] CHAIN_FILE = %s" % CHAIN_FILE)
+					chain = None
+					if os.path.exists(CHAIN_FILE):
+						chain = [crypto.load_certificate(crypto.FILETYPE_PEM, open(CHAIN_FILE, 'rt').read())]
+						vtilog("[OpenWebif] ssl chain file found - loading")
+					context = ssl.CertificateOptions(privateKey=key, certificate=cert, extraCertChain=chain)
 				except:
 					# THIS EXCEPTION IS ONLY CATCHED WHEN CERT FILES ARE BAD (look below for error)
 					print "[OpenWebif] failed to get valid cert files. (It could occure bad file save or format, removing...)"

--- a/plugin/sslcertificate.py
+++ b/plugin/sslcertificate.py
@@ -20,6 +20,7 @@ import os
 CA_FILE = resolveFilename(SCOPE_CONFIG, "ca.pem")
 KEY_FILE = resolveFilename(SCOPE_CONFIG, "key.pem")
 CERT_FILE = resolveFilename(SCOPE_CONFIG, "cert.pem")
+CHAIN_FILE = resolveFilename(SCOPE_CONFIG, "chain.pem")
 
 class SSLCertificateGenerator:
 


### PR DESCRIPTION
- current implementation (via ssl.DefaultOpenSSLContextFactory) does only
  use server certificate (even if complete chain is included in .pem file)
- when using official certificates (like letsencrypt) the chain is required in order
  to supply a valid SSL chain