### PR TITLE
Problem Webif-Web-TV

### DIFF
--- a/Problem Webif-Web-TV
+++ b/Problem Webif-Web-TV
@@ -1,0 +1,17 @@
+Hallo ,
+
+Any news concerning the problem witn Webif-Web-TV?
+
+I have Openatv 6.3 with newest Online UP-Dates, GB Trio, Web-if, webif terminal, webif-themes, web-if -vxg, webif-web-tv loaded 
+from feed as a plugin. PC Windows 10 and Browser Chrome. 
+
+When using web-if web-tv I see after the latest up-date a rotating timer with the notice "for using Nativ -Client press right 
+Mousebottom". After pressing nothing happend, the timer runs always.
+
+With the rigth mouse bottom you kann only shift the Native-Client foreground screen to the background.
+
+The the old mask of web-tv is now seen again but the timer still rotate as bevor.
+
+Already tried to load the Plugins Webif vxg und Web-tv separately but this does not help.
+
+Does anybody has an Info? What is the purpose of Native client? Earlier it was not present and Web-tv works.


### PR DESCRIPTION
Hallo ,

Any news concerning the problem witn Webif-Web-TV?

I have Openatv 6.3 with newest Online UP-Dates, GB Trio, Web-if, webif terminal, webif-themes, web-if -vxg, webif-web-tv loaded 
from feed as a plugin. PC Windows 10 and Browser Chrome. 

When using web-if web-tv I see after the latest up-date a rotating timer with the notice "for using Nativ -Client press right 
Mousebottom". After pressing nothing happend, the timer runs always.

With the rigth mouse bottom you kann only shift the Native-Client foreground screen to the background.

The the old mask of web-tv is now seen again but the timer still rotate as bevor.

Already tried to load the Plugins Webif vxg und Web-tv separately but this does not help.

Does anybody has an Info? What is the purpose of Native client? Earlier it was not present and Web-tv works.