### PR TITLE
Import twisted version from twisted namespace

### DIFF
--- a/plugin/controllers/models/info.py
+++ b/plugin/controllers/models/info.py
@@ -12,7 +12,7 @@
 import os
 import sys
 import time
-from twisted.web import version
+from twisted import version
 from socket import has_ipv6, AF_INET6, AF_INET, inet_ntop, inet_pton, getaddrinfo
 
 import NavigationInstance

--- a/plugin/httpserver.py
+++ b/plugin/httpserver.py
@@ -13,8 +13,9 @@ import enigma
 from Screens.MessageBox import MessageBox
 from Components.config import config
 from Tools.Directories import fileExists
+from twisted import version
 from twisted.internet import reactor, ssl
-from twisted.web import server, http, resource, version
+from twisted.web import server, http, resource
 #from twisted.web import server, http, static, resource, error, version
 from twisted.internet.error import CannotListenError
 from twisted.internet.protocol import Factory, Protocol


### PR DESCRIPTION
Newer version of twisted doesn't expose version under twisted.web namespace.
On the other hand importing the version from twisted namespace seems available
on every version of twisted.

Related commit: https://github.com/twisted/twisted/commit/f743dd1b4b5b42347734c1b8f6618c9dd0551dbb

>>> from twisted.web import version
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name version
>>> from twisted import version
>>> version.major
19