### PR TITLE
Fix wrong path for i18n strings

### DIFF
--- a/plugin/controllers/views/mobile/remote.tmpl
+++ b/plugin/controllers/views/mobile/remote.tmpl
@@ -1,4 +1,4 @@
-#from Plugins.Extensions.OpenWebif.local import tstrings
+#from Plugins.Extensions.OpenWebif.controllers.i18n import tstrings
 <body>
 	<div data-role="page" id="mainPage">
 		<div id="header">


### PR DESCRIPTION
I guess the reference to "local" was somewhen changed to "i18n"?