### PR TITLE
Active OWIF on startSession

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -209,6 +209,7 @@ def IfUpIfDown(reason, **kwargs):
 def startSession(reason, session):
 	global global_session
 	global_session = session
+	HttpdStart(global_session)
 
 
 def main_menu(menuid, **kwargs):


### PR DESCRIPTION
This required after this commit https://github.com/OpenPLi/enigma2/commit/3bdc95336c0025e5971bb7c24e0aa9264f344d37.

Most probably we can get rid of the event WHERE_NETWORKCONFIG_READ as well.