### PR TITLE
[owibranding.py] 3 fixes

### DIFF
--- a/plugin/controllers/models/owibranding.py
+++ b/plugin/controllers/models/owibranding.py
@@ -665,7 +665,13 @@ def getAllInfo():
 
 	info['remote'] = remote
 
-	kernel = about.getKernelVersionString()[0]
+	try:
+		kernel = int(about.getKernelVersionString()[0])
+	except NameError: # when "about" is not available
+		try:
+			kernel = int(open("/proc/version","r").read().split(' ', 4)[2].split('.',2)[0])
+		except: # set a default
+			kernel = 2
 
 	distro = "unknown"
 	imagever = "unknown"


### PR DESCRIPTION
1) Add a "try/except" to avoid a NameError when "about" is not available.
2) Add a default "kernel" value.
3) Typecast kernel to int(), otherwise "if kernel > 2:" will always evaluate to True.