### PR TITLE
Fix light-on-transparent picons "disappearing"

### DIFF
--- a/plugin/controllers/views/responsive/ajax/channels.tmpl
+++ b/plugin/controllers/views/responsive/ajax/channels.tmpl
@@ -7,7 +7,7 @@
 #for $channel in $channels
 <tr>
 #if $showchannelpicon and 'picon' in $channel
-<td style="vertical-align:middle;width:120px;background-color:#bababa;">
+<td style="vertical-align:middle;width:120px;background-color:#bababa;box-shadow:inset -20px 40px 60px white;">
 	<div>
 		<img class="img-fluid" style="max-width:100px;" src="$channel.picon" title="">
 	</div>

--- a/plugin/controllers/views/responsive/ajax/channels.tmpl
+++ b/plugin/controllers/views/responsive/ajax/channels.tmpl
@@ -7,7 +7,7 @@
 #for $channel in $channels
 <tr>
 #if $showchannelpicon and 'picon' in $channel
-<td style="vertical-align:middle;width:120px;">
+<td style="vertical-align:middle;width:120px;background-color:#bababa;">
 	<div>
 		<img class="img-fluid" style="max-width:100px;" src="$channel.picon" title="">
 	</div>


### PR DESCRIPTION
This change adds a background-color (#bababa as used on EPG picon/channelname header row) to avoid white/light picons with transparency "disappearing"

<img width="259" alt="Screen Shot 2020-10-05 at 16 53 35" src="https://user-images.githubusercontent.com/9741693/95103691-d5b07980-072c-11eb-9512-139549cd55f1.png">
<img width="304" alt="Screen Shot 2020-10-05 at 18 50 29" src="https://user-images.githubusercontent.com/9741693/95114335-aead7400-073b-11eb-8aff-08a0cf00ebeb.png">
