### PR TITLE
Sidebar i10n, interface `old`/`new` -> `classic`/`modern` terminology

### DIFF
--- a/locale/OpenWebif.pot
+++ b/locale/OpenWebif.pot
@@ -2089,7 +2089,7 @@ msgid "Use custom box name"
 msgstr ""
 
 #: ../plugin/controllers/i18n.py:473 ../plugin/plugin.py:138
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr ""
 
 #: ../plugin/controllers/i18n.py:271

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -2082,7 +2082,7 @@ msgid "Use custom box name"
 msgstr "إستخدام مخصص لإسم الجهاز"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "استخدام التصميم الجديد"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/bg.po
+++ b/locale/bg.po
@@ -2084,7 +2084,7 @@ msgid "Use custom box name"
 msgstr "Използвай потребителско име на приемника"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Използвай новия дизайн"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -2095,7 +2095,7 @@ msgid "Use custom box name"
 msgstr "Utilitzar nom personalitzat per al deco"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Utilitzar nou diseny"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -2076,7 +2076,7 @@ msgid "Use custom box name"
 msgstr "Použít vlastní název přijímače"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Použít nový vzhled"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/da.po
+++ b/locale/da.po
@@ -2121,7 +2121,7 @@ msgid "Use custom box name"
 msgstr "Brug brugerdefineret boksnavn"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Brug nyt design"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/de.po
+++ b/locale/de.po
@@ -2093,7 +2093,7 @@ msgid "Use custom box name"
 msgstr "Eigenen Boxnamen verwenden"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Nutze neues Design"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/el.po
+++ b/locale/el.po
@@ -2084,7 +2084,7 @@ msgid "Use custom box name"
 msgstr "Χρήση ονόματος χρήστη για το δέκτη"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Χρήση νέας σχεδίασης"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/es.po
+++ b/locale/es.po
@@ -2095,7 +2095,7 @@ msgid "Use custom box name"
 msgstr "Usar nombre personalizado para el deco"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Usar nuevo diseño"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/et.po
+++ b/locale/et.po
@@ -2075,7 +2075,7 @@ msgid "Use custom box name"
 msgstr "Kasuta kohandatud vastuvõtja nime"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Kasuta uut disaini"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/fi.po
+++ b/locale/fi.po
@@ -2093,7 +2093,7 @@ msgid "Use custom box name"
 msgstr "Käytä omaa vastaanotinnimeä"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr ""
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -2089,7 +2089,7 @@ msgid "Use custom box name"
 msgstr "Utiliser un nom personnalisé"
 
 #: ../plugin/controllers/i18n.py:473 ../plugin/plugin.py:138
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Utiliser le nouveau design"
 
 #: ../plugin/controllers/i18n.py:271

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -2076,7 +2076,7 @@ msgid "Use custom box name"
 msgstr "Használjon egyedi box nevet"
 
 #: ../plugin/controllers/i18n.py:473 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Az új kinézet használata"
 
 #: ../plugin/controllers/i18n.py:271

--- a/locale/it.po
+++ b/locale/it.po
@@ -2090,7 +2090,7 @@ msgid "Use custom box name"
 msgstr "Usare un nome ricevitore personalizzato"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Usare nuova interfaccia"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -2100,7 +2100,7 @@ msgid "Use custom box name"
 msgstr "Naudoti savą aparato pavadinimą"
 
 #: ../plugin/controllers/i18n.py:473 ../plugin/plugin.py:138
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Naudoti naują išvaizdą"
 
 #: ../plugin/controllers/i18n.py:271

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -2080,7 +2080,7 @@ msgid "Use custom box name"
 msgstr "Bruk egendefinert mottakernavn"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Bruk ny utforming"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -2087,7 +2087,7 @@ msgid "Use custom box name"
 msgstr "Gebruik een alternatieve naam voor de box"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Gebruik de nieuwe vormgeving"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -2104,7 +2104,7 @@ msgid "Use custom box name"
 msgstr "Użyj niestandardowej nazwy odbiornika"
 
 #: ../plugin/controllers/i18n.py:473 ../plugin/plugin.py:138
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Użyj nowego wyglądu"
 
 #: ../plugin/controllers/i18n.py:271

--- a/locale/pt.po
+++ b/locale/pt.po
@@ -2094,7 +2094,7 @@ msgid "Use custom box name"
 msgstr "Usar o nome do receptor personalizado"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Usar a nova interface"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -2077,7 +2077,7 @@ msgid "Use custom box name"
 msgstr "Использовать пользовательское имя ресивера"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Использование нового дизайна"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -2092,7 +2092,7 @@ msgid "Use custom box name"
 msgstr "Použiť vlastný názov prijímača"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Používať nový dizajn"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -2108,7 +2108,7 @@ msgid "Use custom box name"
 msgstr "Använd anpassat boxnamn"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr ""
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -1507,7 +1507,7 @@ msgstr "Özel Renk Kullan"
 msgid "Use custom box name"
 msgstr "Özel kutu adı kullan"
 
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Yeni tasarım kullan"
 
 msgid "VPS"

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -2085,7 +2085,7 @@ msgid "Use custom box name"
 msgstr "Використовувати альтернативне ім'я ресивера"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "Використовуйте новий дизайн"
 
 #: ../plugin/controllers/i18n.py:270

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -2159,7 +2159,7 @@ msgid "Use custom box name"
 msgstr "使用自定义名称"
 
 #: ../plugin/controllers/i18n.py:472 ../plugin/plugin.py:131
-msgid "Use new design"
+msgid "Use modern interface"
 msgstr "使用新的设计"
 
 msgid "Use custom Color"

--- a/plugin/controllers/i18n.py
+++ b/plugin/controllers/i18n.py
@@ -527,5 +527,9 @@ tstrings = {
 	'autoadjust': _("Adjust recording time to real event time"),
 	'avoidDuplicateMovies': _("Don't create timer when movie exists in database"),
 
-	'streamclients': _("Stream Clients")
+	'streamclients': _("Stream Clients"),
+	'config': _("Config"),
+	'skins': _("Skins"),
+	'use_classic_design': _("Use classic interface"),
+	'use_modern_design': _("Use modern interface")
 }

--- a/plugin/controllers/views/ajax/settings.tmpl
+++ b/plugin/controllers/views/ajax/settings.tmpl
@@ -107,7 +107,7 @@
 				</span>
 				</td></tr>
 				#if $getVar("responsivedesign", "") != ""
-					<tr><td>$tstrings['newdesign']</td><td>
+					<tr><td>$tstrings['use_modern_design']</td><td>
 					#if $responsivedesign
 					<input type="checkbox" name="responsivedesign" checked="checked"/>
 					#else

--- a/plugin/controllers/views/responsive/main.tmpl
+++ b/plugin/controllers/views/responsive/main.tmpl
@@ -342,7 +342,8 @@
 				<!-- it is not allowed to remove this copyright and link when using the materialize (aka responsive) design for openwebif -->
 				<div class="legal" id="leftfooter">
 					<div class="copyright">
-						Materialize design - <b>Version: </b> 1.2.0</br>&copy; <a href="https://www.vuplus-support.org" target="_blank">VTi - vuplus-support.org</a>
+						Materialize design - <b>Version: </b> 1.2.0</br>
+						&copy; <a href="https://www.vuplus-support.org" target="_blank">VTi - vuplus-support.org</a>
 					</div>
 				</div>
 <!-- END COPYRIGHT -->
@@ -351,8 +352,12 @@
 			<!-- #END# Left Sidebar -->
 			<aside id="rightsidebar" class="right-sidebar">
 				<ul class="nav nav-tabs tab-nav-right tab-col-$skinColor" role="tablist">
-					<li role="presentation" class="active"><a href="#settings" data-toggle="tab">$tstrings['settings']</a></li>
-					<li role="presentation"><a href="#skins" data-toggle="tab">SKINS</a></li>
+					<li role="presentation" class="active">
+						<a href="#settings" data-toggle="tab">$tstrings['config']</a>
+					</li>
+					<li role="presentation">
+						<a href="#skins" data-toggle="tab">$tstrings['skins']</a>
+					</li>
 				</ul>
 				<div class="tab-content">
 					<div role="tabpanel" class="tab-pane fade in active in active" id="settings">
@@ -362,13 +367,19 @@
 								<li>
 									<span>$tstrings['epgsearchextended']</span>
 									<div class="switch">
-										<label><input type="checkbox" id="myepgbtn0" $EPGSearchFull><span class="lever switch-col-$skinColor vtiwebconfig"></span></label>
+										<label>
+											<input type="checkbox" id="myepgbtn0" $EPGSearchFull>
+											<span class="lever switch-col-$skinColor vtiwebconfig"></span>
+										</label>
 									</div>
 								</li>
 								<li>
 									<span>$tstrings['epgsearchbouquetsonly']</span>
 									<div class="switch">
-										<label><input type="checkbox" id="myepgbtn1" $EPGSearchBQonly><span class="lever switch-col-$skinColor vtiwebconfig"></span></label>
+										<label>
+											<input type="checkbox" id="myepgbtn1" $EPGSearchBQonly>
+											<span class="lever switch-col-$skinColor vtiwebconfig"></span>
+										</label>
 									</div>
 								</li>
 							</ul>
@@ -377,13 +388,19 @@
 								<li>
 									<span>$tstrings['inc_shortdesc']</span>
 									<div class="switch">
-										<label><input type="checkbox" id="mymoviesearchbtn0" $MovieSearchShort><span class="lever switch-col-$skinColor vtiwebconfig"></span></label>
+										<label>
+											<input type="checkbox" id="mymoviesearchbtn0" $MovieSearchShort>
+											<span class="lever switch-col-$skinColor vtiwebconfig"></span>
+										</label>
 									</div>
 								</li>
 								<li>
 									<span>$tstrings['inc_extdesc']</span>
 									<div class="switch">
-										<label><input type="checkbox" id="mymoviesearchbtn1" $MovieSearchExtended><span class="lever switch-col-$skinColor vtiwebconfig"></span></label>
+										<label>
+											<input type="checkbox" id="mymoviesearchbtn1" $MovieSearchExtended>
+											<span class="lever switch-col-$skinColor vtiwebconfig"></span>
+										</label>
 									</div>
 								</li>
 							</ul>
@@ -393,19 +410,28 @@
 								<li>
 									<span>$tstrings['showfullremoteshort']</span>
 									<div class="switch">
-										<label><input type="checkbox" id="remotecontrolview" $RemoteControlView ><span class="lever switch-col-$skinColor vtiwebconfig"></span></label>
+										<label>
+											<input type="checkbox" id="remotecontrolview" $RemoteControlView>
+											<span class="lever switch-col-$skinColor vtiwebconfig"></span>
+										</label>
 									</div>
 								</li>
 								<li>
 									<span>$tstrings['min_movie_list']</span>
 									<div class="switch">
-										<label><input type="checkbox" id="minmovielist" $MinMovieList><span class="lever switch-col-$skinColor vtiwebconfig"></span></label>
+										<label>
+											<input type="checkbox" id="minmovielist" $MinMovieList>
+											<span class="lever switch-col-$skinColor vtiwebconfig"></span>
+										</label>
 									</div>
 								</li>
 								<li>
 									<span>$tstrings['min_timer_list']</span>
 									<div class="switch">
-										<label><input type="checkbox" id="mintimerlist" $MinTimerList><span class="lever switch-col-$skinColor vtiwebconfig"></span></label>
+										<label>
+											<input type="checkbox" id="mintimerlist" $MinTimerList>
+											<span class="lever switch-col-$skinColor vtiwebconfig"></span>
+										</label>
 									</div>
 								</li>
 								<li>
@@ -415,15 +441,21 @@
 									</div>
 								</li>
 								<li>
-									<span>XSPF Playlist</span>
+									<span>XSPF $tstrings['playlistformat']</span>
 									<div class="switch">
-										<label><input type="checkbox" id="plformat"><span class="lever switch-col-$skinColor vtiwebconfig"></span></label>
+										<label>
+											<input type="checkbox" id="plformat">
+											<span class="lever switch-col-$skinColor vtiwebconfig"></span>
+										</label>
 									</div>
 								</li>
 								<li>
-									<span>Old Design</span>
+									<span>$tstrings['use_classic_design']</span>
 									<div class="switch">
-										<label><input type="checkbox" id="noresposive"><span class="lever switch-col-$skinColor vtiwebconfig"></span></label>
+										<label>
+											<input type="checkbox" id="noresposive">
+											<span class="lever switch-col-$skinColor vtiwebconfig"></span>
+										</label>
 									</div>
 								</li>
 							</ul>
@@ -433,13 +465,19 @@
 								<li>
 									<span>$tstrings['show_picons']</span>
 									<div class="switch">
-										<label><input type="checkbox" id="showpicons" $showPicons><span class="lever switch-col-$skinColor vtiwebconfig"></span></label>
+										<label>
+											<input type="checkbox" id="showpicons" $showPicons>
+											<span class="lever switch-col-$skinColor vtiwebconfig"></span>
+										</label>
 									</div>
 								</li>
 								<li>
 									<span>$tstrings['show_picon_background']</span>
 									<div class="switch">
-										<label><input type="checkbox" id="showpiconbackground" $showPiconBackground><span class="lever switch-col-$skinColor vtiwebconfig"></span></label>
+										<label>
+											<input type="checkbox" id="showpiconbackground" $showPiconBackground>
+											<span class="lever switch-col-$skinColor vtiwebconfig"></span>
+										</label>
 									</div>
 								</li>
 							</ul>

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -136,7 +136,7 @@ class OpenWebifConfig(Screen, ConfigListScreen):
 		self.list = []
 		self.list.append(getConfigListEntry(_("OpenWebInterface Enabled"), config.OpenWebif.enabled))
 		if config.OpenWebif.enabled.value:
-			self.list.append(getConfigListEntry(_("Use new design"), config.OpenWebif.responsive_enabled))
+			self.list.append(getConfigListEntry(_("Use modern interface"), config.OpenWebif.responsive_enabled))
 			if config.OpenWebif.responsive_enabled.value:
 				self.list.append(getConfigListEntry(_("Theme mode"), config.OpenWebif.responsive_themeMode))
 				self.list.append(getConfigListEntry(_("Use custom Color"), config.OpenWebif.responsive_skinColor))


### PR DESCRIPTION
This change:
- updates hardcoded sidebar config strings to internationalised variables
- updates `old`/`new` design -> `classic`/`modern` interface terminology