### PR TITLE
Add hashref to `Remote` menu item

### DIFF
--- a/plugin/controllers/views/responsive/main.tmpl
+++ b/plugin/controllers/views/responsive/main.tmpl
@@ -132,7 +132,7 @@
 						<li class="header" id="leftsidemenuheader">$boxname</li>
 						<li class="active" style="display:none;"></li>
 						<li>
-							<a href="javascript:void(0);" class="menu-toggle">
+							<a href="#remote" class="menu-toggle">
 								<i class="material-icons">dialpad</i>
 								<span>$tstrings['remote']</span>
 							</a>


### PR DESCRIPTION
This change adds `#remote` to sidebar menu item to fix navigation lock-in