### PR TITLE
UI tweaks - Now/Next tab tidyup

### DIFF
--- a/plugin/controllers/views/responsive/ajax/bouquets.tmpl
+++ b/plugin/controllers/views/responsive/ajax/bouquets.tmpl
@@ -7,6 +7,23 @@
 	#set $tabIcon = 'radio'
 #end if
 
+<style>
+	.sticky-top {
+    position: sticky;
+    top: 70px;
+	}
+
+	.sticky-top {
+    background: #fff;
+    box-shadow: 0px 0px 10px 10px #fff;
+	}
+
+	.themed--city-lights .sticky-top {
+    background: #282c37;
+    box-shadow: 0px 0px 10px 10px #282c37;
+	}
+</style>
+
 <div class="form-group hidden-md hidden-lg hidden-xl">
 	<select class="form-control show-tick" id="bqselector">
 	#for $bouquet in $bouquets
@@ -14,7 +31,7 @@
 	#end for
 	</select>
 </div>
-<div class="hidden-sm hidden-xs">
+<div class="hidden-sm hidden-xs sticky-top">
 	<ul class="nav nav-tabs theme-tab-col tab-col-$skinColor">
 	#set $f="id='firstBq'"
 	#for $bouquet in $bouquets

--- a/plugin/controllers/views/responsive/ajax/providers.tmpl
+++ b/plugin/controllers/views/responsive/ajax/providers.tmpl
@@ -3,7 +3,16 @@
 
 <!-- TODO: move style to css file -->
 <style>
-	.nav-tabs>li>a .material-icons { top: 0; margin-bottom: 3px; margin-right: 6px; }
+	.nav-tabs { 
+    flex-wrap: wrap;
+    justify-content: start;
+	}
+
+	.nav-tabs > li > a .material-icons { 
+		top: 0; 
+		margin-bottom: 3px; 
+		margin-right: 6px; 
+	}
 </style>
 
 <ul class="nav nav-tabs theme-tab-col tab-col-$skinColor">

--- a/plugin/controllers/views/responsive/ajax/radio.tmpl
+++ b/plugin/controllers/views/responsive/ajax/radio.tmpl
@@ -5,17 +5,20 @@
 		<div class="header">
 			<div class="row clearfix">
 				<div class="col-xs-12 col-sm-6">
-					<h2><i class="material-icons" style="display:inline-flex;vertical-align:middle !important;margin-right:10px;">radio</i>$tstrings['radio']</h2>
+					<h2>
+						<i class="material-icons" style="display:inline-flex;vertical-align:middle !important;margin-right:10px;">radio</i>
+						$tstrings['radio']
+					</h2>
 				</div>
 			</div>
 			<ul class="header-dropdown">
 				<li class="dropdown">
 					<a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="material-icons">list</i></a>
 					<ul class="dropdown-menu pull-right" id="tvbuttons">
-						<li><a href="javascript:void(0);" id="btn4">$tstrings['all_channels']</a></li>
 						<li><a href="javascript:void(0);" id="btn1">$tstrings['bouquets']</a></li>
 						<li><a href="javascript:void(0);" id="btn2">$tstrings['providers']</a></li>
 						<li><a href="javascript:void(0);" id="btn3">$tstrings['satellites']</a></li>
+						<li><a href="javascript:void(0);" id="btn4">$tstrings['all_channels']</a></li>
 						<li><a href="#current">$tstrings['current']</a></li>
 					</ul>
 				</li>

--- a/plugin/controllers/views/responsive/ajax/satellites.tmpl
+++ b/plugin/controllers/views/responsive/ajax/satellites.tmpl
@@ -4,7 +4,15 @@
 
 <!-- TODO: move style to css file -->
 <style>
-	.nav-tabs>li>a .material-icons { top: 0; margin-bottom: 3px; margin-right: 6px; }
+	.nav-tabs { 
+    flex-wrap: wrap;
+	}
+	
+	.nav-tabs > li > a .material-icons {
+		top: 0; 
+		margin-bottom: 3px; 
+		margin-right: 6px;
+	}
 </style>
 
 <ul class="nav nav-tabs theme-tab-col tab-col-$skinColor" >

--- a/plugin/controllers/views/responsive/ajax/tv.tmpl
+++ b/plugin/controllers/views/responsive/ajax/tv.tmpl
@@ -1,21 +1,66 @@
 #from Plugins.Extensions.OpenWebif.controllers.i18n import tstrings
 
+<style>
+  #tvcontent .nav-tabs {
+		display: flex;
+		margin-bottom: 16px;
+		overflow-x: auto;
+	}
+
+	#tvcontent .nav-tabs > li {
+    position: relative;
+    top: 0;
+    left: 0;
+    margin-bottom: 0;
+    float: none;
+    display: flex;
+		min-width:120px;
+    flex-wrap: wrap;
+    flex: 0 1 auto;
+    justify-content: center;
+    justify-items: center;
+    justify-self: center;
+	}
+
+	#tvcontent .nav-tabs > li > a {
+    display: flex;
+    padding-bottom: 8px;
+    flex: 1 1 auto;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-content: flex-start;
+		text-align: center;
+    transition: 0.2s;
+	}
+	
+	#tvcontent .nav-tabs > li > a .material-icons {
+    position: relative;
+    top: 0;
+		margin: 0 5px 8px;
+	}
+</style>
+
 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
 	<div class="card">
 		<div class="header">
 			<div class="row clearfix">
 				<div class="col-xs-12 col-sm-6">
-					<h2><i class="material-icons material-icons-centered">tv</i>$tstrings['television']</h2>
+					<h2>
+						<i class="material-icons material-icons-centered">tv</i>
+						$tstrings['television']
+					</h2>
 				</div>
 			</div>
 			<ul class="header-dropdown">
 				<li class="dropdown">
-					<a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="material-icons">list</i></a>
+					<a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+						<i class="material-icons">list</i>
+					</a>
 					<ul class="dropdown-menu pull-right" id="tvbuttons">
-						<li><a href="javascript:void(0);" id="btn4">$tstrings['all_channels']</a></li>
 						<li><a href="javascript:void(0);" id="btn1">$tstrings['bouquets']</a></li>
 						<li><a href="javascript:void(0);" id="btn2">$tstrings['providers']</a></li>
 						<li><a href="javascript:void(0);" id="btn3">$tstrings['satellites']</a></li>
+						<li><a href="javascript:void(0);" id="btn4">$tstrings['all_channels']</a></li>
 						<li><a href="#current">$tstrings['current']</a></li>
 					</ul>
 				</li>


### PR DESCRIPTION
This change optimises tab layout on `Now/Next` page, makes tab strip top-sticky.

<img width="299" alt="Screen Shot 2020-11-15 at 21 19 52" src="https://user-images.githubusercontent.com/9741693/99200114-571f1100-279b-11eb-9e65-14a671db064d.png">
<img width="376" alt="Screen Shot 2020-11-15 at 20 29 20" src="https://user-images.githubusercontent.com/9741693/99200115-57b7a780-279b-11eb-9e5f-459a71f9b39b.png">
