### PR TITLE
Fixed sticky bouquet tabs default picon peekaboo

### DIFF
--- a/plugin/controllers/views/responsive/ajax/bouquets.tmpl
+++ b/plugin/controllers/views/responsive/ajax/bouquets.tmpl
@@ -11,6 +11,7 @@
 	.sticky-top {
     position: sticky;
     top: 70px;
+		z-index: 10;
 	}
 
 	.sticky-top {


### PR DESCRIPTION
This change fixes default OpenWebif picon appearing behind the bouquet tab bar