### PR TITLE
Pass through event id from multi epg when deleting a timer.

### DIFF
--- a/plugin/controllers/models/timers.py
+++ b/plugin/controllers/models/timers.py
@@ -396,11 +396,17 @@ def editTimer(session, serviceref, begin, end, name, description, disabled, just
 	}
 
 
-def removeTimer(session, serviceref, begin, end):
+def removeTimer(session, serviceref, begin, end, eit):
 	serviceref_str = ':'.join(str(serviceref).split(':')[:11])
 	rt = session.nav.RecordTimer
 	for timer in rt.timer_list + rt.processed_timers:
 		needed_ref = ':'.join(timer.service_ref.ref.toString().split(':')[:11]) == serviceref_str
+		if needed_ref and timer.eit and eit and timer.eit == eit:
+			rt.removeEntry(timer)
+			return {
+				"result": True,
+				"message": _("The timer '%s' has been deleted successfully") % timer.name
+			}
 		if needed_ref and int(timer.begin) == begin and int(timer.end) == end:
 			rt.removeEntry(timer)
 			return {
@@ -609,7 +615,7 @@ def tvbrowser(session, request):
 		return addTimer(session, sRef, begin, end, name, description, disabled, justplay, afterevent, location, tags, repeated)
 	elif request.args['command'][0] == "del":
 		del request.args['command'][0]
-		return removeTimer(session, sRef, begin, end)
+		return removeTimer(session, sRef, begin, end, eit=None)
 	elif request.args['command'][0] == "change":
 		del request.args['command'][0]
 		return editTimer(session, sRef, begin, end, name, description, disabled, justplay, afterevent, location, tags, repeated, begin, end, serviceref)

--- a/plugin/controllers/web.py
+++ b/plugin/controllers/web.py
@@ -1297,7 +1297,12 @@ class WebController(BaseController):
 				"message": "The parameter 'end' must be a number"
 			}
 
-		return removeTimer(self.session, getUrlArg(request, "sRef"), begin, end)
+		try:
+			eit = int(request.args[b"eit"][0])
+		except Exception:  # noqa: E722
+			eit = None
+
+		return removeTimer(self.session, getUrlArg(request, "sRef"), begin, end, eit)
 
 	def P_timercleanup(self, request):
 		"""

--- a/sourcefiles/js/openwebif.js
+++ b/sourcefiles/js/openwebif.js
@@ -627,7 +627,7 @@ function delTimerEvent(sRef,eventId) {
 				var end = result.event.begin + result.event.duration + 60 * result.event.recording_margin_after;
 				var t = decodeURIComponent(result.event.title);
 				if (confirm(tstr_del_timer + ": " + t) === true) {
-					webapi_execute("/api/timerdelete?sRef=" + sRef + "&begin=" + begin + "&end=" + end, 
+					webapi_execute("/api/timerdelete?sRef=" + sRef + "&begin=" + begin + "&end=" + end + "&eit=" + eventId, 
 						function() { $('.event[data-id='+eventId+'] .timer').remove(); } 
 					);
 				}


### PR DESCRIPTION
If a timer is created by AutoTimer with different (non global) recording margins,
deleting the timer from multi epg doesn't work because no matching timer will be found.

By passing through the event id the timer may be found and thus can be removed.

This fixes at least one case for the "FIXME" comment in openwebif.js