### PR TITLE
Deleting a movie may raise a KeyError exception

### DIFF
--- a/plugin/controllers/models/movies.py
+++ b/plugin/controllers/models/movies.py
@@ -463,7 +463,7 @@ def removeMovie(session, sRef, Force=False):
 		# EMC reload
 		try:
 			config.EMC.needsreload.value = True
-		except AttributeError:
+		except (AttributeError,KeyError):
 			pass
 		return {
 			"result": True,


### PR DESCRIPTION
At least for me the missing EMC does raise a KeyError, not an AttributeError.