### PR TITLE
Fix `<>` appearing on `next` epg when `now` program ends tomorrow

### DIFF
--- a/plugin/controllers/views/responsive/ajax/channels.tmpl
+++ b/plugin/controllers/views/responsive/ajax/channels.tmpl
@@ -132,6 +132,9 @@
 			<td class="now-next__no-data">$tstrings['no_epg_data']</td>
 #end if
 #if (not $isProtected) and 'next_title' in $channel
+		#if $channel.next_title == "<<absent>>"
+			<td colspan="2" class="now-next__no-data">...</td>
+		#else
 			<td>
 				<div>
 					<h2 class="now-next__title">
@@ -142,6 +145,7 @@
 					<div>&nbsp;</div>
 				</div>
 			</td>
+		#end if
 #else
 			<td colspan="2" class="now-next__no-data">$tstrings['no_epg_data']</td>
 #end if


### PR DESCRIPTION
Fix `<>` appearing on `next` epg when `now` program ends tomorrow

<img width="1018" alt="Screen Shot 2021-02-26 at 23 43 40" src="https://user-images.githubusercontent.com/9741693/109368805-40a44d80-7892-11eb-957c-1f799a229cda.png">

<img width="1024" alt="Screen Shot 2021-02-26 at 23 44 12" src="https://user-images.githubusercontent.com/9741693/109368812-46019800-7892-11eb-90d4-c85e059d7524.png">
