### PR TITLE
Dynamic OpenWebif url

### DIFF
--- a/locale/OpenWebif.pot
+++ b/locale/OpenWebif.pot
@@ -1292,8 +1292,8 @@ msgstr ""
 msgid "OpenWebif Settings"
 msgstr ""
 
-#: ../plugin/plugin.py:122
-msgid "OpenWebif url: http://yourip:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
 msgstr ""
 
 #: ../plugin/controllers/i18n.py:441

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -1287,8 +1287,8 @@ msgid "OpenWebif Settings"
 msgstr "إعدادات الإنترنت المفتوح"
 
 #: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "رابط الإنترنت المفتوح: http://yourip:port"
+msgid "OpenWebif URL:"
+msgstr "رابط الإنترنت المفتوح:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/bg.po
+++ b/locale/bg.po
@@ -1288,9 +1288,9 @@ msgstr "OpenWebif Настройки"
 msgid "OpenWebif Settings"
 msgstr "OpenWebif Настройки"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://IP приемник:порт"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -1296,9 +1296,9 @@ msgstr "Configuració OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "Configuració OpenWebif"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "Enllaç OpenWebif: http://ip:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "Enllaç OpenWebif:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -1283,9 +1283,9 @@ msgstr "Nastavení OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "Nastavení OpenWebif"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://vašeip:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/da.po
+++ b/locale/da.po
@@ -1301,9 +1301,9 @@ msgstr "OpenWebif konfiguration"
 msgid "OpenWebif Settings"
 msgstr "OpenWebif indstillinger"
 
-#: ../plugin/plugin.py:122
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif URL: http://ipadresse:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:441
 #: ../plugin/controllers/models/services.py:259

--- a/locale/de.po
+++ b/locale/de.po
@@ -1295,9 +1295,9 @@ msgstr "OpenWebif-Konfiguration"
 msgid "OpenWebif Settings"
 msgstr "OpenWebif Einstellungen"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif-URL: http://ip_des_receivers:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif-URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/el.po
+++ b/locale/el.po
@@ -1286,9 +1286,9 @@ msgstr "Ρυθμίσεις OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "Ρυθμίσεις OpenWebif"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://yourip:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/es.po
+++ b/locale/es.po
@@ -1296,9 +1296,9 @@ msgstr "Configuración OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "Configuración OpenWebif"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "Enlace OpenWebif: http://tuip:puerto"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "Enlace OpenWebif:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/et.po
+++ b/locale/et.po
@@ -1282,9 +1282,9 @@ msgstr "Veebiliidese seaded"
 msgid "OpenWebif Settings"
 msgstr "OpenWebif seaded"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://sinu_ip:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/fi.po
+++ b/locale/fi.po
@@ -1294,9 +1294,9 @@ msgstr "OpenWebif-asetukset"
 msgid "OpenWebif Settings"
 msgstr "OpenWebif asetukset"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif-url: http://ip-osoite:portti"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif-URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -1292,9 +1292,9 @@ msgstr "Configuration OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "Paramètres OpenWebif"
 
-#: ../plugin/plugin.py:122
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://yourip:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:441
 #: ../plugin/controllers/models/services.py:259

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -1283,9 +1283,9 @@ msgstr "OpenWebif konfiguráció"
 msgid "OpenWebif Settings"
 msgstr "OpenWebif beállítások"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://yourip:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:441
 #: ../plugin/controllers/models/services.py:239

--- a/locale/it.po
+++ b/locale/it.po
@@ -1292,9 +1292,9 @@ msgstr "Configurazione OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "OpenWebif"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "Indirizzo OpenWebif: http://ip_ricevitore:porta"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "Indirizzo OpenWebif:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -1303,9 +1303,9 @@ msgstr "OpenWebif konfigūravimas"
 msgid "OpenWebif Settings"
 msgstr "OpenWebif nuostatos"
 
-#: ../plugin/plugin.py:122
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif nuoroda: http://imtuvo_IP:prievadas"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif nuoroda:"
 
 #: ../plugin/controllers/i18n.py:441
 #: ../plugin/controllers/models/services.py:259

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -1285,9 +1285,9 @@ msgstr "OpenWebif innstilling"
 msgid "OpenWebif Settings"
 msgstr "OpenWebif innstilling"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://dinip:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -1294,9 +1294,9 @@ msgstr "Openwebif configuratie"
 msgid "OpenWebif Settings"
 msgstr "Openwebif instellingen"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "Openwebif url: http://uwIP:poort"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "Openwebif URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -1307,9 +1307,9 @@ msgstr "Konfiguracja OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "Ustawienia OpenWebif"
 
-#: ../plugin/plugin.py:122
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http: // twój ip: port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:441
 #: ../plugin/controllers/models/services.py:259

--- a/locale/pt.po
+++ b/locale/pt.po
@@ -1295,9 +1295,9 @@ msgstr "Configuração OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "Definições OpenWebif"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://o_seu_ip:porta"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -1284,9 +1284,9 @@ msgstr "Настройки OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "Настройки OpenWebif"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://IP ресивера:порт"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -1293,9 +1293,9 @@ msgstr "Nastavenie OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "Nastavenia OpenWebif"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif adresa: http://vašaIP:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif adresa:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -1299,9 +1299,9 @@ msgstr "Inställningar för OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "Inställningar för OpenWebif"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://din_ipadress:port"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -937,8 +937,8 @@ msgstr "OpenWebif Yapılandırması"
 msgid "OpenWebif Settings"
 msgstr "OpenWebif Ayarları"
 
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://yourip:port"
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 msgid "Orbital Position"
 msgstr "Yörünge Konumu"

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -1289,9 +1289,9 @@ msgstr "Налаштування OpenWebif"
 msgid "OpenWebif Settings"
 msgstr "Налаштування Веб-інтерфейса"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif url: http://IP ресивера:порт"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif URL:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -1329,9 +1329,9 @@ msgstr "网页管理配置"
 msgid "OpenWebif Settings"
 msgstr "OpenWebif设置"
 
-#: ../plugin/plugin.py:115
-msgid "OpenWebif url: http://yourip:port"
-msgstr "OpenWebif 访问: http://您的IP地址:端口"
+#: ../plugin/plugin.py:138
+msgid "OpenWebif URL:"
+msgstr "OpenWebif 访问:"
 
 #: ../plugin/controllers/i18n.py:440
 #: ../plugin/controllers/models/services.py:225

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -30,6 +30,7 @@ from Components.ActionMap import ActionMap
 from Components.Label import Label
 from Components.ConfigList import ConfigListScreen
 from Components.config import config, getConfigListEntry, ConfigSubsection, ConfigInteger, ConfigYesNo, ConfigText, ConfigSelection, configfile
+from Components.Network import iNetwork
 from enigma import getDesktop
 from Plugins.Extensions.OpenWebif.controllers.models.info import getInfo
 from Plugins.Extensions.OpenWebif.controllers.defaults import EXT_EVENT_INFO_SOURCE
@@ -123,7 +124,18 @@ class OpenWebifConfig(Screen, ConfigListScreen):
 		ConfigListScreen.__init__(self, self.list)
 		self["key_red"] = Label(_("Cancel"))
 		self["key_green"] = Label(_("Save"))
-		self["lab1"] = Label(_("OpenWebif url: http://yourip:port"))
+
+		owif_protocol = "https" if config.OpenWebif.https_enabled.value else "http"
+		owif_port = config.OpenWebif.https_port.value if config.OpenWebif.https_enabled.value else config.OpenWebif.port.value
+		ifaces = iNetwork.getConfiguredAdapters()
+		if len(ifaces):
+			ip_list = iNetwork.getAdapterAttribute(ifaces[0], "ip")  # use only the first configured interface
+			if ip_list:
+				ip = "%d.%d.%d.%d" % (ip_list[0], ip_list[1], ip_list[2], ip_list[3])
+			else:
+				ip = _("box_ip")
+
+		self["lab1"] = Label("%s\n%s://%s:%d" % (_("OpenWebif url:"), owif_protocol, ip, owif_port))
 
 		self["actions"] = ActionMap(["WizardActions", "ColorActions"],
 		{


### PR DESCRIPTION
Dynamic OpenWebif url on plugin settings page

This change shows the _actual_ url instead of `http://yourip:port`

![1_0_16_83F_3EA_2174_EEEE0000_0_0_0_20210322200257](https://user-images.githubusercontent.com/9741693/112053980-ed4db400-8b4c-11eb-9aee-e5be9818b402.jpg)

