### PR TITLE
Now/Next columns vs stacked (#1289)

### DIFF
--- a/plugin/controllers/ajax.py
+++ b/plugin/controllers/ajax.py
@@ -89,6 +89,7 @@ class AjaxController(BaseController):
 		channels['type'] = stype
 		channels['showpicons'] = config.OpenWebif.webcache.showpicons.value
 		channels['showpiconbackground'] = config.OpenWebif.responsive_show_picon_background.value
+		channels['shownownextcolumns'] = config.OpenWebif.responsive_nownext_columns_enabled.value
 		return channels
 
 	def P_eventdescription(self, request):

--- a/plugin/controllers/views/responsive/ajax/channels.tmpl
+++ b/plugin/controllers/views/responsive/ajax/channels.tmpl
@@ -69,6 +69,9 @@
 	}
 
 	.now-next__info {
+		justify-content: space-between;
+		display: flex;
+		flex-wrap: wrap;
 		flex: 4;
 		min-width: 320px;
 	}
@@ -80,9 +83,9 @@
 
 	.now-next__details {
 		display: flex;
-    flex-wrap: wrap;
-    width: 100%;
+		flex-wrap: wrap;
 		white-space: normal;
+		width: 48%;
 	}
 
 	.now-next__details--now {
@@ -98,6 +101,11 @@
 	.now-next__details--next {
 		opacity: 0.6;
 	}
+#if not $shownownextcolumns
+	.now-next__details {
+		flex: 1 0 100%;
+	}
+#end if
 </style>
 
 <div class="table-responsive block-header">

--- a/plugin/vtiaddon.py
+++ b/plugin/vtiaddon.py
@@ -227,4 +227,5 @@ def expandConfig():
 	config.OpenWebif.responsive_moviesearch_short = ConfigYesNo(default=False)
 	config.OpenWebif.responsive_rcu_full_view = ConfigYesNo(default=False)
 	config.OpenWebif.responsive_show_picon_background = ConfigYesNo(default=False)
+	config.OpenWebif.responsive_nownext_columns_enabled = ConfigYesNo(default=False)
 	config.OpenWebif.autotimer_regex_searchtype = ConfigYesNo(default=False)


### PR DESCRIPTION
Now/Next columns vs stacked (#1289)

This change enables side-by-side
```
now|next
```
vs
```
now
---
next
```

by adding
`config.OpenWebif.responsive_nownext_columns_enabled=true`
to /etc/enigma2/settings file