### PR TITLE
Modern UI implementation for #1344

### DIFF
--- a/plugin/controllers/views/responsive/ajax/at.tmpl
+++ b/plugin/controllers/views/responsive/ajax/at.tmpl
@@ -143,7 +143,8 @@
 				</div>
 				<div class="col-xs-8">
 					<ul class="header-dropdown" style="top: 0; right: 5px;">
-						<li><button type="button" name="rename" title="$tstrings['rename']" class="m-0" style="border: none; background: none;"><i class="material-icons material-icons-mg-right">drive_file_rename_outline</i></button></li>
+						<li><button type="button" name="preview" data-toggle="modal" data-target="#ATPreviewModal" title="$tstrings['at_preview']" class="m-0" style="border: none; background: none;"><i class="material-icons material-icons-mg-right">view_list</i></button></li>
+						<li><button type="button" name="rename" title="$tstrings['rename']" class="m-0" style="border: none; background: none;"><i class="material-icons material-icons-mg-right">swap_horiz</i></button></li>
 						<li><a href="#/at/edit?id={{id}}" title="$tstrings['at_edit']"><i class="material-icons material-icons-mg-right">edit</i></a> 
 						<li><button type="button" name="toggle" title="$tstrings['enable_disable']" class="m-0" style="border: none; background: none;"><i class="material-icons material-icons-mg-right">alarm_off</i></button></li>
 						<li><button type="button" name="delete" title="$tstrings['at_del']"><i class="material-icons material-icons-mg-right">delete_outline</i></button></li>
@@ -227,7 +228,6 @@
 						<a href="#/at/new" class="btn btn--skinned waves-effect"><i class="material-icons">add</i><span>$tstrings['at_new']</span></a>
 						<button type="button" name="reload" class="btn btn--skinned waves-effect"><i class="material-icons">refresh</i><span>$tstrings['reload']</span></button>
 						<button type="button" name="process" class="btn btn--skinned waves-effect"><i class="material-icons">code</i><span>$tstrings['at_process']</span></span></button>
-						<button type="button" name="preview" data-toggle="modal" data-target="#ATPreviewModal" class="btn btn--skinned waves-effect"><i class="material-icons">view_list</i><span>$tstrings['at_preview']</span></button>
 						<button type="button" name="timers" data-toggle="modal" data-target="#ATTimerListModal" class="btn btn--skinned waves-effect"><i class="material-icons" class="btn btn--skinned waves-effect">alarm</i><span>$tstrings['at_timers']</span></button>
 						<button type="button" name="settings" data-toggle="modal" data-target="#ATSettingsModal" class="btn btn--skinned waves-effect" data-title="$tstrings['ats_auto_timer_settings']"><i class="material-icons">settings</i><span>$tstrings['at_settings']</span></button>
 					</div>

--- a/sourcefiles/modern/js/autotimers.js
+++ b/sourcefiles/modern/js/autotimers.js
@@ -349,6 +349,7 @@
             const searchType = valueLabelMap.autoTimers.searchType[atItem['searchType']] || '';
             const newNode = templateEl.content.firstElementChild.cloneNode(true);
 
+            newNode.querySelector('button[name="preview"]').onclick = (evt) => self.preview(atItem.id);
             newNode.querySelector('[name="rename"]').onclick = (evt) => self.renameEntry(atItem.id, atItem.name);
 
             const editEl = newNode.querySelector('a[href="#/at/edit?id={{id}}"]');
@@ -475,12 +476,12 @@
         }
       },
 
-      preview: async () => {
+      preview: async (id) => {
         document.getElementById('at-preview__progress').classList.toggle('hidden', false);
         document.getElementById('at-preview__no-results').classList.toggle('hidden', true);
-        const responseContent = await owif.utils.fetchData('/autotimer/test');
-        const data = responseContent['e2autotimertest'];
-        const autotimers = data['e2testtimer'] || [];
+        const responseContent = await owif.utils.fetchData('/autotimer/test?id='+id);
+        const data = responseContent['e2autotimersimulate'] || responseContent['e2autotimertest'];
+        const autotimers = data['e2testtimer'] || date['e2simulatedtimer'];
         const previewTbodyEl = document.getElementById('at-preview__list');
         const newNode = document.createElement('tbody');
         document.getElementById('at-preview__progress').classList.toggle('hidden', true);


### PR DESCRIPTION
Move the preview button from the head section to the entries section.

Rename the rename icon as well because "drive_file_rename_outline" doesn't seem to be available in the used font.

Please check.