### PR TITLE
Fixed #EXTVLCOPT key/value separator

### DIFF
--- a/plugin/controllers/file.py
+++ b/plugin/controllers/file.py
@@ -70,7 +70,7 @@ class FileController(resource.Resource):
 				if m is not None:
 					port = m.group(1)
 
-				response = "#EXTM3U\n#EXTVLCOPT--http-reconnect=true\n#EXTINF:-1,%s\n%s://%s:%s/file?action=download&file=%s" % (name, proto, request.getRequestHostname(), port, quote(filename))
+				response = "#EXTM3U\n#EXTVLCOPT:http-reconnect=true\n#EXTINF:-1,%s\n%s://%s:%s/file?action=download&file=%s" % (name, proto, request.getRequestHostname(), port, quote(filename))
 				request.setHeader("Content-Disposition", 'attachment;filename="%s.m3u"' % name)
 				request.setHeader("Content-Type", "application/x-mpegurl")
 				return response

--- a/plugin/controllers/models/stream.py
+++ b/plugin/controllers/models/stream.py
@@ -125,11 +125,11 @@ def getStream(session, request, m3ufile):
 	else:
 		auth = ''
 
-	response = "#EXTM3U \n#EXTVLCOPT--http-reconnect=true \n%shttp://%s%s:%s/%s%s\n" % (progopt, auth, request.getRequestHostname(), portNumber, sRef, args)
+	response = "#EXTM3U \n#EXTVLCOPT:http-reconnect=true \n%shttp://%s%s:%s/%s%s\n" % (progopt, auth, request.getRequestHostname(), portNumber, sRef, args)
 	if config.OpenWebif.playiptvdirect.value:
 		if "http://" in sRef or "https://" in sRef:
 			l = sRef.split(":http")[1]
-			response = "#EXTM3U \n#EXTVLCOPT--http-reconnect=true\n%shttp%s\n" % (progopt, l)
+			response = "#EXTM3U \n#EXTVLCOPT:http-reconnect=true\n%shttp%s\n" % (progopt, l)
 	request.setHeader('Content-Type', 'application/x-mpegurl')
 	# Note: do not rename the m3u file all the time
 	fname = getUrlArg(request, "fname")
@@ -245,7 +245,7 @@ def getTS(self, request):
 		else:
 			auth = ''
 
-		response = "#EXTM3U \n#EXTVLCOPT--http-reconnect=true \n%s%s://%s%s:%s/file?file=%s%s\n" % ((progopt, proto, auth, request.getRequestHostname(), portNumber, quote(filename), args))
+		response = "#EXTM3U \n#EXTVLCOPT:http-reconnect=true \n%s%s://%s%s:%s/file?file=%s%s\n" % ((progopt, proto, auth, request.getRequestHostname(), portNumber, quote(filename), args))
 		request.setHeader('Content-Type', 'application/x-mpegurl')
 		return response
 	else:

--- a/plugin/controllers/views/web/movielistm3u.tmpl
+++ b/plugin/controllers/views/web/movielistm3u.tmpl
@@ -1,6 +1,6 @@
 #from six.moves.urllib.parse import quote
 #EXTM3U
-#EXTVLCOPT--http-reconnect=true
+#EXTVLCOPT:http-reconnect=true
 #for $movie in $movies
 #EXTINF:-1,: $movie.filename_stripped
 $host/file?file=$quote($movie.filename)

--- a/plugin/controllers/views/web/servicesm3u.tmpl
+++ b/plugin/controllers/views/web/servicesm3u.tmpl
@@ -1,6 +1,6 @@
 #from Plugins.Extensions.OpenWebif.controllers.models.services import getPicon
 #EXTM3U 
-#EXTVLCOPT--http-reconnect=true
+#EXTVLCOPT:http-reconnect=true
 #set $_url = "http://"+$auth+$host.split(u":")[0]
 #for $service in $services
 #set $_sref=":".join($service.servicereference.split(":", 10)[:-1])+":"

--- a/testsuite/status_quo_file_controller.py
+++ b/testsuite/status_quo_file_controller.py
@@ -40,7 +40,7 @@ class TestEnigma2FileAPICalls(unittest.TestCase):
 		req = requests.get(self.file_url, params=params)
 		print("Tried to fetch {!r}".format(req.url))
 		# print(req.text)
-		expected_body = '#EXTM3U\n#EXTVLCOPT--http-reconnect=true\n#EXTINF:-1,stream\nhttp://{netloc}:80/file?action=download&file=/etc/passwd'.format(netloc=self.enigma2_host)
+		expected_body = '#EXTM3U\n#EXTVLCOPT:http-reconnect=true\n#EXTINF:-1,stream\nhttp://{netloc}:80/file?action=download&file=/etc/passwd'.format(netloc=self.enigma2_host)
 		self.assertEqual(expected_body, req.text)
 		self.assertEqual(200, req.status_code)
 


### PR DESCRIPTION
Replaced command line `--` in #EXTVLCOPT with m3u key/value separator `:`