### PR TITLE
Support for DVB-S2 radio stations

### DIFF
--- a/sourcefiles/js/bqe.js
+++ b/sourcefiles/js/bqe.js
@@ -118,7 +118,7 @@
 				if (self.Mode === 0) {
 					r = '1:7:1:0:0:0:0:0:0:0:(type == 1) || (type == 17) || (type == 195) || (type == 25) || (type == 22) || (type == 31) || (type == 211) ';
 				} else {
-					r = '1:7:2:0:0:0:0:0:0:0:(type == 2) ';
+					r = '1:7:2:0:0:0:0:0:0:0:(type == 2) || (type == 10) ';
 				}
 				if (type === 0) {
 					r += 'FROM BOUQUET "bouquets.';


### PR DESCRIPTION
Without that change, the public German radio broadcasting services won't be visible in the bouquet editor, even if they appear in the channel list.
E.g. "MDR AKTUELL" now uses service ID 1:0:A:28F0:425:1:C00000:0:0:0:, the 'A' (10 decimal) at the third position identifies a S2 radio station.