### PR TITLE
Minor (mainly layout) bugfixes

### DIFF
--- a/plugin/controllers/views/responsive/ajax/channels.tmpl
+++ b/plugin/controllers/views/responsive/ajax/channels.tmpl
@@ -28,7 +28,7 @@
 		<tr id="sref-$channel.ref.replace(':', '_')" class="channel-list__channel">
 	#if '1:64:' in $channel.ref
 			<th colspan="3" class="now-next__header header bg--skinned">
-				<h2>$channelName</h2>
+				<h2 class="bg--skinned">$channelName</h2>
 			</th>
 	#else
 #if $showPicons and 'picon' in $channel

--- a/plugin/controllers/views/responsive/ajax/channels.tmpl
+++ b/plugin/controllers/views/responsive/ajax/channels.tmpl
@@ -11,7 +11,11 @@
 	.now-next__header {
 		width: 100%;
 	}
-#if not $shownownextcolumns
+#if $shownownextcolumns
+	.now-next__details--now {
+		border-bottom: none;
+	}
+#else
 	.now-next__details {
 		flex: 1 0 100%;
 	}

--- a/plugin/controllers/views/responsive/ajax/channels.tmpl
+++ b/plugin/controllers/views/responsive/ajax/channels.tmpl
@@ -8,6 +8,9 @@
 
 <!-- TODO: move styles to css file -->
 <style>
+	.now-next__header {
+		width: 100%;
+	}
 #if not $shownownextcolumns
 	.now-next__details {
 		flex: 1 0 100%;
@@ -24,9 +27,9 @@
 
 		<tr id="sref-$channel.ref.replace(':', '_')" class="channel-list__channel">
 	#if '1:64:' in $channel.ref
-			<td colspan="3" class="now-next__header header bg--skinned">
+			<th colspan="3" class="now-next__header header bg--skinned">
 				<h2>$channelName</h2>
-			</td>
+			</th>
 	#else
 #if $showPicons and 'picon' in $channel
 	#set $piconHTML = '<img class="img-fluid" src="%s" alt="Channel logo" loading="lazy">' % $channel.picon

--- a/plugin/controllers/views/responsive/ajax/channels.tmpl
+++ b/plugin/controllers/views/responsive/ajax/channels.tmpl
@@ -24,7 +24,7 @@
 
 		<tr id="sref-$channel.ref.replace(':', '_')" class="channel-list__channel">
 	#if '1:64:' in $channel.ref
-			<td colspan="100%" class="now-next__header header bg--skinned">
+			<td colspan="3" class="now-next__header header bg--skinned">
 				<h2>$channelName</h2>
 			</td>
 	#else

--- a/plugin/controllers/views/responsive/ajax/settings.tmpl
+++ b/plugin/controllers/views/responsive/ajax/settings.tmpl
@@ -121,11 +121,11 @@
 						<div id="content_main2">
 							<div class="row clearfix">
 								<div class="col-xs-12">
-									<ul class="nav nav-tabs" >
-										<li><a data-toggle="tab" href='#tab' class="pkgbtn" id='pkgbtn1' >$tstrings['update']</a></li>
-										<li><a data-toggle="tab" href='#tab' class="pkgbtn" id='pkgbtn2' >$tstrings['installed']</a></li>
-										<li><a data-toggle="tab" href='#tab' class="pkgbtn" id='pkgbtn3' >$tstrings['all']</a></li>
-										<li><a data-toggle="tab" href='#tab' class="pkgbtn" id='pkgbtn4' >$tstrings['more']</a></li>
+									<ul class="nav nav-tabs tab--skinned">
+										<li><a data-toggle="tab" href="#tab" class="pkgbtn" id="pkgbtn1">$tstrings['update']</a></li>
+										<li><a data-toggle="tab" href="#tab" class="pkgbtn" id="pkgbtn2">$tstrings['installed']</a></li>
+										<li><a data-toggle="tab" href="#tab" class="pkgbtn" id="pkgbtn3">$tstrings['all']</a></li>
+										<li><a data-toggle="tab" href="#tab" class="pkgbtn" id="pkgbtn4">$tstrings['more']</a></li>
 									</ul>
 								</div>
 							</div>

--- a/plugin/controllers/views/responsive/main.tmpl
+++ b/plugin/controllers/views/responsive/main.tmpl
@@ -30,7 +30,7 @@
 ]
 
 <!doctype html>
-<html lang="$stbLang">
+<html lang="$stbLang.replace('_', '-')">
 <head>
 	<title>$boxname - OpenWebif</title>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sourcefiles/modern/css/themes/all-themes.css
+++ b/sourcefiles/modern/css/themes/all-themes.css
@@ -1,6 +1,6 @@
 /* variables setup */
 :root {
-	--palette--red:          #f44336;
+  --palette--red:          #f44336;
   --palette--pink:         #e91e63;
   --palette--purple:       #9c27b0;
   --palette--deep-purple:  #673ab7;

--- a/sourcefiles/modern/css/themes/all-themes.css
+++ b/sourcefiles/modern/css/themes/all-themes.css
@@ -285,7 +285,7 @@ input[type="range"]::-ms-thumb {
 .sweet-alert button.confirm,
 .choices__list--multiple .choices__item {
   background-color: var(--skin-color) !important;
-  color: var(--main-text-color);
+  color: var(--main-text-color) !important;
 }
 
 .spinner-layer.pl--skinned {


### PR DESCRIPTION
This change comprises an assortment of minor bugfixes:

- Fix html `lang` value to use RFC 5646 format
- Fix unwanted line in `now` blocks when in column mode
- Fix marker header text colour
- Fix file indent
- Fix marker header width
- Fix tab colour mismatch on `Settings` | `Packages` page