### PR TITLE
Remove header `(i)` icon

### DIFF
--- a/plugin/controllers/base.py
+++ b/plugin/controllers/base.py
@@ -426,8 +426,6 @@ class BaseController(resource.Resource):
 		smallremote = config.OpenWebif.webcache.smallremote.value if config.OpenWebif.webcache.smallremote.value else 'new'
 		ret['smallremote'] = smallremote
 		ret['textinputsupport'] = TEXTINPUTSUPPORT
-		try:
-			ret['debugModeEnabled'] = config.OpenWebif.displayTracebacks.value == True
-		except:
-			ret['debugModeEnabled'] = False
+		ret['debugModeEnabled'] = config.OpenWebif.displayTracebacks.value == True
+
 		return ret

--- a/plugin/controllers/base.py
+++ b/plugin/controllers/base.py
@@ -426,4 +426,8 @@ class BaseController(resource.Resource):
 		smallremote = config.OpenWebif.webcache.smallremote.value if config.OpenWebif.webcache.smallremote.value else 'new'
 		ret['smallremote'] = smallremote
 		ret['textinputsupport'] = TEXTINPUTSUPPORT
+		try:
+			ret['debugModeEnabled'] = config.OpenWebif.displayTracebacks.value == True
+		except:
+			ret['debugModeEnabled'] = False
 		return ret

--- a/plugin/controllers/views/responsive/main.tmpl
+++ b/plugin/controllers/views/responsive/main.tmpl
@@ -3,7 +3,6 @@
 #from Plugins.Extensions.OpenWebif.controllers.defaults import OPENWEBIFVER, OPENWEBIFPACKAGEVERSION, USERCSSRESPONSIVE
 #from json import dumps
 
-#set $debugMode = False
 #set $skinPrefOptions = [
 	{'value': 'black', 'label': 'Black'}, 
 	{'value': 'grey-darken-4', 'label': 'Dark Grey'}, 
@@ -110,9 +109,6 @@
 					<button class="bars" id="leftsidebarin"></button>
 					<h1 id="header__title">
 						<a href="/">OpenWebif</a>
-						<button id="header__info" data-toggle="modal" data-target="#OwifVersionModal">
-							<i class="icon material-icons">info_outline</i>
-						</button>
 					</h1>
 					<button style="display: none;" id="osd__connection" title="$tstrings['no_network_connection']"><i class="icon material-icons">link_off</i></button>
 				</div>
@@ -170,7 +166,7 @@
 						<i class="icon material-icons">search</i>
 					</button>
 <!--
-#if $vti == "1" or $debugMode
+#if $vti == "1"
 -->
 					<button class="js-search-movie" data-close="true" title="$tstrings['moviesearch']">
 						<i class="icon material-icons">youtube_searched_for</i>
@@ -401,7 +397,7 @@
                                 </li>
 								<li><a href="#about">OpenWebif</a></li>
 <!--
-#if $debugMode
+#if $debugModeEnabled
 -->
 								<li class="disabled" style="user-select: all;"><!-- these `disabled` classes will prevent the `Waves` plugin interfering with text selection -->
                                     <a href="javascript:void(0);" class="disabled" style="user-select: all;">$tstrings['version']: $OPENWEBIFVER</a>
@@ -694,24 +690,6 @@
 
 <!---<div id="modaldialog"></div>-->
 <div id="responsivespinner"></div>
-<div id="OwifVersionModal" class="modal fade" role="dialog">
-	<div class="modal-dialog modal-lg">
-		<div class="modal-content">
-			<div class="modal-header bg--skinned">
-				<button type="button" class="close" data-dismiss="modal">
-					<i class="material-icons material-icons-centered">close</i>
-				</button>
-				<span class="modal-title">OpenWebif Version Information</span>
-			</div>
-			<div class="modal-body" style="max-height: calc(100vh - 180px); overflow-y: auto;">
-				This information has been moved into <b>Information</b> in the main menu.
-			</div>
-			<div class="modal-footer">
-				<button type="button" class="btn waves-effect btn-default" data-dismiss="modal">$tstrings['close']</button>
-			</div>
-		</div>
-	</div>
-</div>
 <div id="TimerConflictModal" class="modal fade" role="dialog">
 	<div class="modal-dialog modal-lg">
 		<div class="modal-content">


### PR DESCRIPTION
Remove header `(i)` icon

OWIF version information was previously moved to the side menu `Information` section (#1465).

To enable, set `Debug - Enable tracebacks` in OWIF plugin page.