### PR TITLE
Move package version details into `About OpenWebif` page (#1509)

### DIFF
--- a/plugin/controllers/views/responsive/ajax/about.tmpl
+++ b/plugin/controllers/views/responsive/ajax/about.tmpl
@@ -1,3 +1,4 @@
+#from Plugins.Extensions.OpenWebif.controllers.defaults import OPENWEBIFVER, OPENWEBIFPACKAGEVERSION
 #from Plugins.Extensions.OpenWebif.controllers.i18n import tstrings
 
 <div class="col-xs-12">
@@ -78,6 +79,21 @@
   | <a href="https://getbootstrap.com" target="_blank" class="link--skinned" rel="noreferrer noopener">Bootstrap - v3.3.6</a>
                     </li>
                   </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="row clearfix">
+          <div class="col-xs-12">
+            <div class="card">
+              <div class="header bg--skinned">
+                <h2><i class="material-icons material-icons-centered">troubleshoot</i>$tstrings['version']</h2>
+              </div>
+              <div class="body">
+                <div class="row clearfix" style="text-align: center;">
+                    <p>$OPENWEBIFVER</p>
+                    <p>$tstrings['build']: $OPENWEBIFPACKAGEVERSION</p>
                 </div>
               </div>
             </div>

--- a/plugin/controllers/views/responsive/main.tmpl
+++ b/plugin/controllers/views/responsive/main.tmpl
@@ -1,6 +1,6 @@
 #from Plugins.Extensions.OpenWebif.controllers.i18n import tstrings
 #from Plugins.Extensions.OpenWebif.vtiaddon import skinColor, themeMode, EPGSearchBQonly, EPGSearchFull, ScreenshotOnRCU, MinMovieList, MinTimerList, MinEPGList, MovieSearchExtended, MovieSearchShort, RemoteControlView, showPicons, showPiconBackground, ZapStream, showIPTVChannelsInSelection, useSreenshotChannelName, useNowNextColumns
-#from Plugins.Extensions.OpenWebif.controllers.defaults import OPENWEBIFVER, OPENWEBIFPACKAGEVERSION, USERCSSRESPONSIVE
+#from Plugins.Extensions.OpenWebif.controllers.defaults import USERCSSRESPONSIVE
 #from json import dumps
 
 #set $skinPrefOptions = [
@@ -396,16 +396,6 @@
                                     <a href="#boxinfo" data-close="true" accesskey="i" title="Shortcut: i">$tstrings['receiver']</a>
                                 </li>
 								<li><a href="#about">OpenWebif</a></li>
-<!--
-#if $debugModeEnabled
--->
-								<li class="disabled" style="user-select: all;"><!-- these `disabled` classes will prevent the `Waves` plugin interfering with text selection -->
-                                    <a href="javascript:void(0);" class="disabled" style="user-select: all;">$tstrings['version']: $OPENWEBIFVER</a>
-                                    <a href="javascript:void(0);" class="disabled" style="user-select: all;">$tstrings['build']: $OPENWEBIFPACKAGEVERSION</a>
-								</li>
-<!--
-#end if
--->
 							</ul>
 						</li>
 						<li>


### PR DESCRIPTION
Move package version details into `About OpenWebif` page

This change moves package version details from hidden-by-default side menu item into always-visible `About OpenWebif` page (#1509)

<img width="1186" alt="" src="https://user-images.githubusercontent.com/9741693/170980486-09f6b353-8ebe-4e3a-af58-7bdbf28ced46.png">


