### PR TITLE
Introduce `Find similar events` functionality (modern)

### DIFF
--- a/plugin/controllers/ajax.py
+++ b/plugin/controllers/ajax.py
@@ -25,7 +25,7 @@ from Components.config import config
 from time import mktime, localtime
 import os
 
-from Plugins.Extensions.OpenWebif.controllers.models.services import getBouquets, getChannels, getAllServices, getSatellites, getProviders, getEventDesc, getChannelEpg, getSearchEpg, getCurrentFullInfo, getMultiEpg, getEvent
+from Plugins.Extensions.OpenWebif.controllers.models.services import getBouquets, getChannels, getAllServices, getSatellites, getProviders, getEventDesc, getSimilarEpg, getChannelEpg, getSearchEpg, getCurrentFullInfo, getMultiEpg, getEvent
 from Plugins.Extensions.OpenWebif.controllers.models.info import getInfo
 from Plugins.Extensions.OpenWebif.controllers.models.movies import getMovieList, getMovieSearchList, getMovieInfo
 from Plugins.Extensions.OpenWebif.controllers.models.timers import getTimers
@@ -130,11 +130,15 @@ class AjaxController(BaseController):
 		events = []
 		timers = []
 		sref = getUrlArg(request, "sref")
+		eventId = getUrlArg(request, "eventid")
 		sstr = getUrlArg(request, "sstr")
-		if sref != None:
-			ev = getChannelEpg(sref)
+		if sref is not None:
+			if eventId is not None:
+				ev = getSimilarEpg(sref, eventId)
+			else:
+				ev = getChannelEpg(sref)
 			events = ev["events"]
-		elif sstr != None:
+		elif sstr is not None:
 			fulldesc = False
 			if getUrlArg(request, "full") != None:
 				fulldesc = True

--- a/plugin/controllers/epg.py
+++ b/plugin/controllers/epg.py
@@ -150,8 +150,11 @@ class EPG():
 
 		criteria = (SEARCH_FIELDS, MAX_RESULTS, eEPGCache.SIMILAR_BROADCASTINGS_SEARCH, sRef, eventId)
 		with TimedProcess() as tp:
-			epgEvents = self._instance.search(criteria) or []
-			epgEvents = [self._transformEventData(SEARCH_FIELDS, evt) for evt in epgEvents]
+			epgEvents = self._instance.search(criteria)
+			if epgEvents is None:
+				epgEvents = []
+			else:
+				epgEvents = [self._transformEventData(SEARCH_FIELDS, evt) for evt in epgEvents]
 
 		# debug(tp.getTimeTaken(), "EPG")
 

--- a/plugin/controllers/epg.py
+++ b/plugin/controllers/epg.py
@@ -150,7 +150,7 @@ class EPG():
 
 		criteria = (SEARCH_FIELDS, MAX_RESULTS, eEPGCache.SIMILAR_BROADCASTINGS_SEARCH, sRef, eventId)
 		with TimedProcess() as tp:
-			epgEvents = self._instance.search(criteria)
+			epgEvents = self._instance.search(criteria) or []
 			epgEvents = [self._transformEventData(SEARCH_FIELDS, evt) for evt in epgEvents]
 
 		# debug(tp.getTimeTaken(), "EPG")

--- a/plugin/controllers/epg.py
+++ b/plugin/controllers/epg.py
@@ -151,10 +151,11 @@ class EPG():
 		criteria = (SEARCH_FIELDS, MAX_RESULTS, eEPGCache.SIMILAR_BROADCASTINGS_SEARCH, sRef, eventId)
 		with TimedProcess() as tp:
 			epgEvents = self._instance.search(criteria)
+			epgEvents = [self._transformEventData(SEARCH_FIELDS, evt) for evt in epgEvents]
 
 		# debug(tp.getTimeTaken(), "EPG")
 
-		debug(epgEvents[-1].toJSON(indent=2) if epgEvents and len(epgEvents) else epgEvents, "EPG")
+		# debug(epgEvents[-1].toJSON(indent=2) if epgEvents and len(epgEvents) else epgEvents, "EPG")
 		return epgEvents
 
 	@staticmethod

--- a/plugin/controllers/i18n.py
+++ b/plugin/controllers/i18n.py
@@ -139,6 +139,7 @@ tstrings = {
 	'error': _("Error"),
 	'every_timer': _("Every"),
 	'extras': _("Extras"),
+	'find_similar_events': _("Find similar events"),
 	'finished': _("finished"),
 	'firmware_version': _("Firmware version"),
 	'fp_version': _("Front processor version"),

--- a/plugin/controllers/models/services.py
+++ b/plugin/controllers/models/services.py
@@ -796,7 +796,7 @@ def getEvent(sRef, eventId, encode=True):
 		return None
 
 
-def getChannelEpg(ref, begintime=-1, endtime=-1, encode=True):
+def getChannelEpg(ref, begintime = -1, endtime = -1, encode = True, eventId = None):
 	ret = []
 	ev = {}
 	use_empty_ev = False
@@ -811,7 +811,11 @@ def getChannelEpg(ref, begintime=-1, endtime=-1, encode=True):
 
 		picon = getPicon(_ref)
 		epg = EPG()
-		epgEvents = epg.getChannelEvents(_ref, begintime, endtime)
+
+		if eventId is not None:
+			epgEvents = epg.findSimilarEvents(ref, eventId)
+		else:
+			epgEvents = epg.getChannelEvents(ref, begintime, endtime)
 
 		if epgEvents is not None:
 			for epgEvent in epgEvents:
@@ -833,11 +837,12 @@ def getChannelEpg(ref, begintime=-1, endtime=-1, encode=True):
 					ev['shortdesc'] = convertDesc(epgEvent.shortDescription, encode)
 					ev['longdesc'] = convertDesc(epgEvent.longDescription, encode)
 					ev['sname'] = filterName(epgEvent.service['name'], encode)
-					ev['tleft'] = epgEvent.remaining['minutes']
-					ev['progress'] = epgEvent.progress['number']
 					ev['now_timestamp'] = 0
 					ev['genre'] = epgEvent.genre
 					ev['genreid'] = epgEvent.genreId
+					if eventId is None:
+						ev['tleft'] = epgEvent.remaining['minutes']
+						ev['progress'] = epgEvent.progress['number']
 					ret.append(ev)
 				else:
 					use_empty_ev = True
@@ -865,6 +870,10 @@ def getChannelEpg(ref, begintime=-1, endtime=-1, encode=True):
 		ret.append(ev)
 
 	return {"events": ret, "result": True}
+
+
+def getSimilarEpg(sRef, eventId):
+	return getChannelEpg(sRef, None, None, None, eventId)
 
 
 def getBouquetEpg(bqRef, begintime=-1, endtime=-1, encode=False):

--- a/plugin/controllers/models/services.py
+++ b/plugin/controllers/models/services.py
@@ -796,7 +796,7 @@ def getEvent(sRef, eventId, encode=True):
 		return None
 
 
-def getChannelEpg(ref, begintime = -1, endtime = -1, encode = True, eventId = None):
+def getChannelEpg(ref, begintime=-1, endtime=-1, encode=True, eventId=None):
 	ret = []
 	ev = {}
 	use_empty_ev = False
@@ -872,8 +872,8 @@ def getChannelEpg(ref, begintime = -1, endtime = -1, encode = True, eventId = No
 	return {"events": ret, "result": True}
 
 
-def getSimilarEpg(sRef, eventId):
-	return getChannelEpg(sRef, None, None, None, eventId)
+def getSimilarEpg(sRef, eventId, encode=False):
+	return getChannelEpg(sRef, None, None, encode, eventId)
 
 
 def getBouquetEpg(bqRef, begintime=-1, endtime=-1, encode=False):
@@ -1080,40 +1080,6 @@ def getSearchEpg(sstr, endtime=None, fulldesc=False, bouquetsonly=False, encode=
 				ev['ns'] = getOrb(nsi >> 16 & 0xFFF)
 			else:
 				ev['ns'] = ns
-
-	return {"events": ret, "result": True}
-
-
-def getSearchSimilarEpg(sRef, eventId, encode=False):
-	sRef = unquote(sRef)
-	ret = []
-	ev = {}
-	epg = EPG()
-	epgEvents = epg.findSimilarEvents(sRef, eventId)
-
-	if epgEvents is not None:
-		# TODO : discuss #677
-		# events.sort(key = lambda x: (x[1],x[6])) # sort by date,sname
-		# events.sort(key = lambda x: x[1]) # sort by date
-
-		for epgEvent in epgEvents:
-			ev = {}
-			ev['id'] = epgEvent[0]
-			ev['date'] = "%s %s" % (tstrings[("day_" + strftime("%w", (localtime(epgEvent[1]))))], strftime(_("%d.%m.%Y"), (localtime(epgEvent[1]))))
-			ev['begin_timestamp'] = epgEvent[1]
-			ev['begin'] = strftime("%H:%M", (localtime(epgEvent[1])))
-			ev['duration_sec'] = epgEvent[2]
-			ev['duration'] = int(epgEvent[2] / 60)
-			ev['end'] = strftime("%H:%M", (localtime(epgEvent[1] + epgEvent[2])))
-			ev['title'] = filterName(epgEvent[3], encode)
-			ev['shortdesc'] = convertDesc(epgEvent[4], encode)
-			ev['longdesc'] = convertDesc(epgEvent[5], encode)
-			ev['sref'] = epgEvent[7]
-			ev['sname'] = filterName(epgEvent[6], encode)
-			ev['picon'] = getPicon(epgEvent[7])
-			ev['now_timestamp'] = None
-			ev['genre'], ev['genreid'] = convertGenre(epgEvent[8])
-			ret.append(ev)
 
 	return {"events": ret, "result": True}
 

--- a/plugin/controllers/views/responsive/ajax/event.tmpl
+++ b/plugin/controllers/views/responsive/ajax/event.tmpl
@@ -132,10 +132,13 @@
 #end if
 
 #if $at
-		<button class="link--not-skinned" onclick='location.href="#/at/new?name=$title&match=$title&timespanFrom=$event.begin_str&timespanTo=$event.end&sref=$sref";' class="link--not-skinned" title="$tstrings['add_autotimer']" data-dismiss="modal">
+		<button onclick='location.href="#/at/new?name=$title&match=$title&timespanFrom=$event.begin_str&timespanTo=$event.end&sref=$sref";' class="link--not-skinned" title="$tstrings['add_autotimer']" data-dismiss="modal">
 			<i class="material-icons material-icons-centered">av_timer</i>
 		</button>
 #end if
+		<button type="button" onclick="open_epg_similar_dialog('$sRefQuoteEscaped', '$event.id');" class="link--not-skinned" title="$tstrings['find_similar_events']" data-toggle="modal" data-target="#EPGModal">
+			<i class="icon material-icons material-icons-centered">dynamic_feed</i>
+		</button>
 	</div>
 </div>
 </div>

--- a/plugin/controllers/web.py
+++ b/plugin/controllers/web.py
@@ -28,7 +28,7 @@ from Components.config import config as comp_config
 from Screens.InfoBar import InfoBar
 
 from .models.info import getInfo, getCurrentTime, getStatusInfo, getFrontendStatus, testPipStatus
-from .models.services import getCurrentService, getBouquets, getServices, getSubServices, getSatellites, getBouquetEpg, getBouquetNowNextEpg, getMultiChannelNowNextEpg, getSearchEpg, getChannelEpg, getNowNextEpg, getSearchSimilarEpg, getAllServices, getPlayableServices, getPlayableService, getParentalControlList, getEvent, getServiceRef, getPicon
+from .models.services import getCurrentService, getBouquets, getServices, getSubServices, getSatellites, getBouquetEpg, getBouquetNowNextEpg, getMultiChannelNowNextEpg, getSearchEpg, getSimilarEpg, getChannelEpg, getNowNextEpg, getAllServices, getPlayableServices, getPlayableService, getParentalControlList, getEvent, getServiceRef, getPicon
 from .models.volume import getVolumeStatus, setVolumeUp, setVolumeDown, setVolumeMute, setVolume
 from .models.audiotrack import getAudioTracks, setAudioTrack
 from .models.control import zapService, remoteControl, setPowerState, getStandbyState
@@ -1678,7 +1678,7 @@ class WebController(BaseController):
 				"result": False,
 				"message": "The parameter 'eventid' must be a number"
 			}
-		return getSearchSimilarEpg(getUrlArg(request, "sRef"), eventid, self.isJson)
+		return getSimilarEpg(getUrlArg(request, "sRef"), eventid, self.isJson)['events']
 
 	# http://enigma2/api/event?idev=32695&sref=1%3A0%3A19%3A1B1F%3A802%3A2%3A11A0000%3A0%3A0%3A0%3A
 	# (/web/event returns a 404 in both `classic` and `modern` interfaces

--- a/sourcefiles/modern/js/vti-responsive.js
+++ b/sourcefiles/modern/js/vti-responsive.js
@@ -162,6 +162,12 @@ function open_epg_dialog(sRef,Name) {
 	$.get(url, set_epg_modal_content);
 }
 
+function open_epg_similar_dialog(sRef, eventId) {
+	$("#epgmodalcontent").html(loadspinner);
+	var url = "ajax/epgdialog?sref=" + encodeURIComponent(sRef) + "&eventid=" + eventId;
+	$.get(url, set_epg_modal_content);
+}
+
 function load_channelsepg(url) {
 	$("#channel_epg_container").load(url);
 	return false;


### PR DESCRIPTION
This change introduces `Find similar events` to an event's detail dialog.

Known issue: _no similar events_ scenarios aren't yet gracefully handled

<img width="388" alt="" src="https://user-images.githubusercontent.com/9741693/185799815-663b8097-8c2c-4a79-b6ef-bd843b6ffe1a.png">

