### PR TITLE
Fix display of events for different channels (sRefs's) with identical…

### DIFF
--- a/plugin/controllers/models/services.py
+++ b/plugin/controllers/models/services.py
@@ -1155,9 +1155,10 @@ def getMultiEpg(self, ref, begintime=-1, endtime=None, Mode=1):
 		return timerDetails
 
 	ret = OrderedDict()
+	channelnames = {}
 	services = eServiceCenter.getInstance().list(eServiceReference(ref))
 	if not services:
-		return {"events": ret, "result": False, "slot": None}
+		return {"events": ret, "channelnames": channelnames, "result": False, "slot": None}
 
 	sRefs = services.getContent('S')
 	epg = EPG()
@@ -1229,7 +1230,7 @@ def getMultiEpg(self, ref, begintime=-1, endtime=None, Mode=1):
 			if Mode == 2:
 				ev['duration'] = epgEvent.duration['seconds']
 
-			channel = filterName(epgEvent.service['name'])
+			channel = epgEvent.service['sRef']
 
 			if channel not in ret:
 				if Mode == 1:
@@ -1238,6 +1239,7 @@ def getMultiEpg(self, ref, begintime=-1, endtime=None, Mode=1):
 					ret[channel] = [[]]
 
 				picons[channel] = getPicon(epgEvent.service['sRef'])
+				channelnames[channel] = filterName(epgEvent.service['name'])
 
 			if Mode == 1:
 				slot = int((epgEvent.start['timestamp'] - offset) / 7200)
@@ -1248,7 +1250,7 @@ def getMultiEpg(self, ref, begintime=-1, endtime=None, Mode=1):
 					ret[channel][slot].append(ev)
 			else:
 				ret[channel][0].append(ev)
-	return {"events": ret, "result": True, "picons": picons}
+	return {"events": ret, "channelnames": channelnames, "result": True, "picons": picons}
 
 
 def getPicon(sname, pp=None, defaultpicon=True):

--- a/plugin/controllers/views/ajax/multiepg.tmpl
+++ b/plugin/controllers/views/ajax/multiepg.tmpl
@@ -118,7 +118,7 @@
 		#set $ev=$evl[0]
 		#set $ref = "data-ref='" + $ev.ref + "'"
 	#end if
-	<td class="border"><div class="service ui-widget-header" $ref><img src="$(picons[$sname])" /> $sname</div></td>
+	<td class="border"><div class="service ui-widget-header" $ref><img src="$(picons[$sname])" /> $(channelnames[$sname])</div></td>
 	#end for
 </tr>
 </thead>
@@ -141,7 +141,7 @@
 <tfoot>
 <tr>
 	#for $sname, $eventlist in six.iteritems($events)
-	<td class="border"><div class="service ui-widget-header"><img src="$(picons[$sname])" /> $sname</div></td>
+	<td class="border"><div class="service ui-widget-header"><img src="$(picons[$sname])" /> $(channelnames[$sname])</div></td>
 	#end for
 </tr>
 </tfoot>
@@ -186,8 +186,8 @@
 			<li>
 				<span class="ui-widget-header">
 					<div>
-						<h2 class="picon" ><img src="$(picons[$sname])" title="$sname" /></h2>
-						<span>$sname</span>
+						<h2 class="picon" ><img src="$(picons[$sname])" title="$(channelnames[$sname])" /></h2>
+						<span>$(channelnames[$sname])</span>
 					</div>
 				</span>
 				<ol cass="eventlist">

--- a/plugin/controllers/views/responsive/ajax/multiepg.tmpl
+++ b/plugin/controllers/views/responsive/ajax/multiepg.tmpl
@@ -211,7 +211,7 @@
 	#set $ref = "data-ref='" + $ev.ref + "'"
 #end if
 				<td class="serviceheader">
-					<div class="service event" $ref><img src="$(picons[$sname])" loading="lazy">$sname</div>
+					<div class="service event" $ref><img src="$(picons[$sname])" loading="lazy">$(channelnames[$sname])</div>
 				</td>
 #end for
 			</tr>
@@ -253,8 +253,8 @@
 #for $sname, $eventlist in six.iteritems($events)
 									<div class="row epg__row">
 										<div class="epg__channel pull-left">
-											<h2 class="picon"><img src="$(picons[$sname])" title="$sname" loading="lazy"></h2>
-											</br><label>$sname</label>
+											<h2 class="picon"><img src="$(picons[$sname])" title="$(channelnames[$sname])" loading="lazy"></h2>
+											</br><label>$(channelnames[$sname])</label>
 										</div>
 									</div>
 #end for


### PR DESCRIPTION
… channel names in Multi-EPG

If a bouquet contains channels from e.g. different sources (DVB-S, DVB-C) with the same name, their events were subsumed under one column. Each event was displayed multiple times. Fix this by indexing the channel by service reference.