### PR TITLE
Fix small error when getting EPG data

### DIFF
--- a/plugin/controllers/models/info.py
+++ b/plugin/controllers/models/info.py
@@ -593,7 +593,7 @@ def getStreamServiceAndEvent(ref):
 	epg = EPG()
 	event = epg.getCurrentEvent(ref)
 	if event:
-		eventname = event.getEventName()
+		eventname = event.title
 	return sname, eventname
 
 


### PR DESCRIPTION
Found this problem when playing around with the `GetStreamInfo()` function. Before, the list of streams would not be populated because the code never ran successfully.

Also restores the stream display in the header:
![image](https://user-images.githubusercontent.com/1127491/198215317-07e96382-cb70-4f5c-bf6a-ff4b23dd7ac0.png)

https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/blob/72620ea3121d3d7a6f14f4038d22fb6b87c47e34/plugin/controllers/models/info.py#L810-L811
https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/blob/72620ea3121d3d7a6f14f4038d22fb6b87c47e34/sourcefiles/modern/js/vti-responsive.js#L374