### PR TITLE
Port away from imp module, use importlib instead

### DIFF
--- a/plugin/controllers/base.py
+++ b/plugin/controllers/base.py
@@ -24,7 +24,10 @@ from __future__ import print_function
 import os
 import json
 import six
-from importlib.util import spec_from_file_location, module_from_spec
+if six.PY3:
+	from importlib.util import spec_from_file_location, module_from_spec
+else:
+	import imp
 
 from twisted.web import server, http, resource
 from twisted.web.resource import EncodingResourceWrapper
@@ -126,11 +129,11 @@ class BaseController(resource.Resource):
 	def loadTemplate(self, path, module, args):
 		template = None
 		if fileExists(getViewsPath(path + ".pyo")):
-			template = self.load_source(module, getViewsPath(path + ".pyo"))
+			template = self.load_source(module, getViewsPath(path + ".pyo")) if six.PY3 else imp.load_compiled(module, getViewsPath(path + ".pyo"))
 		elif fileExists(getViewsPath(path + ".pyc")):
-			template = self.load_source(module, getViewsPath(path + ".pyc"))
+			template = self.load_source(module, getViewsPath(path + ".pyc")) if six.PY3 else imp.load_compiled(module, getViewsPath(path + ".pyc"))
 		elif fileExists(getViewsPath(path + ".py")):
-			template = self.load_source(module, getViewsPath(path + ".py"))
+			template = self.load_source(module, getViewsPath(path + ".py")) if six.PY3 else imp.load_source(module, getViewsPath(path + ".py"))
 		if template:
 			mod = getattr(template, module, None)
 			if callable(mod):

--- a/plugin/httpserver.py
+++ b/plugin/httpserver.py
@@ -38,7 +38,6 @@ from OpenSSL import crypto
 from Components.Network import iNetwork
 
 import os
-import imp
 import ipaddress
 import six
 
@@ -158,11 +157,6 @@ def buildRootTree(session):
 					continue
 
 				loaded.append(modulename)
-				try:
-					imp.load_source(modulename, origwebifpath + "/WebChilds/External/" + modulename + ".py")
-				except Exception as e:
-					# maybe there's only the compiled version
-					imp.load_compiled(modulename, origwebifpath + "/WebChilds/External/" + external)
 
 		if len(loaded_plugins) > 0:
 			for plugin in loaded_plugins:


### PR DESCRIPTION
Based on:
https://github.com/oe-alliance/OpenWebif/commit/b10e510c7624e76100567620f92e1c9ca1b0f45c https://github.com/oe-alliance/OpenWebif/commit/4612bbf64ef0f1d73a38b295e3dfad24ad9882d4

Remove redundant code.

Thank @jbleyel.

Tested with Python 3.9.9 (.pyc files) and Python 3.12 (.py files).