### PR TITLE
copypasta SSL info from #125 to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ See also #215
 ### Problems with a custom Certificate
 
 Creating key and cert is beyond the scope of this readme.
-I found [Ivan Ristić's ](https://www.feistyduck.com/books/openssl-cookbook/) helpful.
+I found [Ivan Ristić's openssl cookbook](https://www.feistyduck.com/books/openssl-cookbook/) helpful.
 
 FWIW, an `ecparam` `secp384r1` key and a `ecdsa-with-SHA256` cert with 4 SAN worked just fine on the following;
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ init 3
 
 ---
 
+## Custom SSL Certificate
+
+If you want to use your own certificate, then replace both `/etc/enigma2/key.pem` and `/etc/enigma2/cert.pem` with your own key and cert, in PEM format.
+
+Restart Enigma2 after replacing those files.
+
+### Using your own CA
+
+You can also put the ca cert as `/etc/enigma2/ca.pem` and enable HTTPS Client Cert auth in settings you can even login using Client certs signed by the same CA auth.
+
+It doesn't bypass the password login yet and you should of course use your own CA, because else any client with a key signed by that CA auth can login, as there is no option to limit access to certain users (yet, and probably newer will be).
+
+See also #215
+
+---
+
 ## Development Information
 
 See what's been happening, check out the [OpenWebif changelog](CHANGES.md)

--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ It doesn't bypass the password login yet and you should of course use your own C
 
 See also #215
 
+### Problems with a custom Certificate
+
+Creating key and cert is beyond the scope of this readme.
+I found [Ivan Ristić's ](https://www.feistyduck.com/books/openssl-cookbook/) helpful.
+
+FWIW, an `ecparam` `secp384r1` key and a sha256 cert with 4 SAN worked just fine with the following;
+
+```bash
+root@vuduo4kse:~# date ; cat /etc/os-release 
+Wed Nov 29 22:58:24 CET 2023
+ID=openbh
+NAME="openbh"
+VERSION="5.1"
+VERSION_ID=5.1
+PRETTY_NAME="openbh 5.1"
+```
+
 ---
 
 ## Development Information

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ See also #215
 Creating key and cert is beyond the scope of this readme.
 I found [Ivan Ristić's ](https://www.feistyduck.com/books/openssl-cookbook/) helpful.
 
-FWIW, an `ecparam` `secp384r1` key and a sha256 cert with 4 SAN worked just fine with the following;
+FWIW, an `ecparam` `secp384r1` key and a `ecdsa-with-SHA256` cert with 4 SAN worked just fine on the following;
 
 ```bash
 root@vuduo4kse:~# date ; cat /etc/os-release 


### PR DESCRIPTION
relates to #215 

Like other users commenting on #215 I came across that issue by using a search engine to find where OpenWebif expects to find the key and cert so that I could configure my own SSL certificate.

This trivial PR takes the information from #215 into the main readme (which is where I was hoping to find it).

Adjust as needed and feel free to drop c95af923f41ae5cc145f71a25ed26f8c7444725b  fbd5c83bd94628bf2ca16e98b9b3d8497fd1ccc2 and 52042c5c3940fbb4dd12865344c3ba15ab350099
(No affiliation to Mr Ristić, I just found his cookbook useful when making my first homelab CA)