### PR TITLE
Potential fix for code scanning alert no. 25: Incomplete string escaping or encoding

### DIFF
--- a/sourcefiles/modern/plugins/momentjs/moment.js
+++ b/sourcefiles/modern/plugins/momentjs/moment.js
@@ -800,7 +800,7 @@ function getParseRegexForToken(token, config) {
 function unescapeFormat(s) {
     return regexEscape(
         s
-            .replace('\\', '')
+            .replace(/\\/g, '')
             .replace(/\\(\[)|\\(\])|\[([^\]\[]*)\]|\\(.)/g, function (
                 matched,
                 p1,


### PR DESCRIPTION
Potential fix for [https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/25](https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/25)

To fix the problem, we need to ensure that **all occurrences** of the backslash (`\`) in the string `s` are replaced. This can be achieved by using a regular expression with the global flag (`g`) instead of the current string literal. Specifically, `replace('\\', '')` should be replaced with `replace(/\\/g, '')`. This ensures that every instance of the backslash is removed from the string as intended.

The change will be made in the `unescapeFormat` function on line 803. No other parts of the code need modification. The functionality of `regexEscape` remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
