### PR TITLE
Potential fix for code scanning alert no. 24: Incomplete string escaping or encoding

### DIFF
--- a/sourcefiles/modern/plugins/jquery/jquery-ui-1.12.1.js
+++ b/sourcefiles/modern/plugins/jquery/jquery-ui-1.12.1.js
@@ -1561,7 +1561,7 @@ var keycode = $.ui.keyCode = {
 
 // Internal use only
 var escapeSelector = $.ui.escapeSelector = ( function() {
-	var selectorEscape = /([!"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g;
+	var selectorEscape = /([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g;
 	return function( selector ) {
 		return selector.replace( selectorEscape, "\\$1" );
 	};


### PR DESCRIPTION
Potential fix for [https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/24](https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/24)

To fix the incomplete escaping bug in the `escapeSelector` function, we need to ensure that the backslash character itself is also escaped. This is accomplished by modifying the regular expression `selectorEscape` to include the backslash (`\`) as a character to be matched and escaped. In JavaScript regular expressions, a backslash must be double-escaped (`\\\\`) in the regex source to match a literal backslash. Update the regular expression so that it matches backslash as well as the existing set of special characters. No additional methods or imports are required; only the regex definition needs to be changed.

Specifically, edit the definition of `selectorEscape` on line 1564 to include the backslash, like so:  
`var selectorEscape = /([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g;`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
