### PR TITLE
Potential fix for code scanning alert no. 23: Incomplete string escaping or encoding

### DIFF
--- a/sourcefiles/js/openwebif.js
+++ b/sourcefiles/js/openwebif.js
@@ -771,7 +771,7 @@ function setOSD( statusinfo )
 		var _osdch = "<span class='osdch'>" + station + "</span></a>&nbsp;&nbsp;";
 		var _beginend = _osdch + statusinfo.currservice_begin + " - " + statusinfo.currservice_end + "&nbsp;&nbsp;";
 		var desc = statusinfo.currservice_fulldescription;
-		desc = desc.replace(/'/g,"\\'");
+		desc = desc.replace(/\\/g, '\\\\').replace(/'/g,"\\'");
 
 		if ((sref.indexOf("1:0:1") !== -1) || (sref.indexOf("1:134:1") !== -1)) {
 			if (statusinfo.transcoding) {


### PR DESCRIPTION
Potential fix for [https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/23](https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/23)

To fix the incomplete escaping, both backslashes (`\`) and single quotes (`'`) must be escaped in the string, in that order (to avoid double-escaping the backslashes introduced during quote escaping). The best way to do this is to first replace every backslash (`\`) with a double backslash (`\\`), and then replace every single quote (`'`) with a backslash-single-quote (`\'`). This ensures that any existing backslashes do not interfere with the escaping of single quotes, and that the resulting string is safe to insert into a single-quoted JavaScript or HTML attribute. The changes only need to be made in the region where `desc.replace(/'/g,"\\'")` is currently used (line 774). No new libraries are needed, and the code remains functionally unchanged except for the more robust escaping.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
