### PR TITLE
Potential fix for code scanning alert no. 22: Incomplete string escaping or encoding

### DIFF
--- a/sourcefiles/js/openwebif.js
+++ b/sourcefiles/js/openwebif.js
@@ -764,7 +764,7 @@ function setOSD( statusinfo )
 	current_name = station;
 	
 	if (station) {
-		var stationA = station.replace(/'/g,"\\'");
+		var stationA = station.replace(/\\/g, '\\\\').replace(/'/g,"\\'");
 		var stream = "<div id='osdicon'>";
 		var streamtitle = tstr_stream + ": " + station + "'><i class='fa fa-desktop'></i></a>";
 		var streamtitletrans = tstr_stream + " (" + tstr_transcoded + "): " + station + "'><i class='fa fa-mobile'></i></a>";


### PR DESCRIPTION
Potential fix for [https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/22](https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/22)

To fix the problem, we should escape both backslashes and single quotes in the `station` variable, so that the resulting string can be safely embedded in a single-quoted string literal in HTML or JavaScript. The general approach is to first replace all backslashes (`\`) with double backslashes (`\\`), then replace all single quotes (`'`) with escaped single quotes (`\'`). This matches what is done on line 774 for `desc`. The fix should be applied on line 767, replacing the current `station.replace(/'/g,"\\'")` with `station.replace(/\\/g, '\\\\').replace(/'/g,"\\'")`. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
