### PR TITLE
Potential fix for code scanning alert no. 20: Incomplete multi-character sanitization

### DIFF
--- a/sourcefiles/modern/plugins/bootstrap-select/js/bootstrap-select.js
+++ b/sourcefiles/modern/plugins/bootstrap-select/js/bootstrap-select.js
@@ -722,7 +722,13 @@
       }
 
       //strip all html-tags and trim the result
-      this.$button.attr('title', $.trim(title.replace(/<[^>]*>?/g, '')));
+      var sanitizedTitle = title;
+      var prevSanitizedTitle;
+      do {
+        prevSanitizedTitle = sanitizedTitle;
+        sanitizedTitle = sanitizedTitle.replace(/<[^>]*>?/g, '');
+      } while (sanitizedTitle !== prevSanitizedTitle);
+      this.$button.attr('title', $.trim(sanitizedTitle));
       this.$button.children('.filter-option').html(title);
 
       this.$element.trigger('rendered.bs.select');


### PR DESCRIPTION
Potential fix for [https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/20](https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/20)

To fix this issue, we should apply the replacement repeatedly until no more matches are found. This ensures that if removing a tag exposes a new tag (as in the case of nested or malformed tags), it will also be removed. Specifically, we should wrap the `replace` operation in a loop that continues until the string stops changing. This fix should be applied in the relevant line within `render` where the title attribute is set. No external libraries are strictly necessary for this fix, since we are limited to the code shown and should avoid introducing new dependencies unless required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
