### PR TITLE
Potential fix for code scanning alert no. 21: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/sourcefiles/modern/plugins/jquery/jquery-2.2.4.js
+++ b/sourcefiles/modern/plugins/jquery/jquery-2.2.4.js
@@ -5322,7 +5322,8 @@ function remove( elem, selector, keepData ) {
 
 jQuery.extend( {
 	htmlPrefilter: function( html ) {
-		return html.replace( rxhtmlTag, "<$1></$2>" );
+		// Disabled unsafe expansion of self-closing tags for security reasons.
+		return html;
 	},
 
 	clone: function( elem, dataAndEvents, deepDataAndEvents ) {


### PR DESCRIPTION
Potential fix for [https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/21](https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/21)

To fix the unsafe expansion of self-closing HTML tags, we should avoid using a regex-based approach to modify HTML structure, especially on potentially untrusted input. Instead, we should parse the HTML using a trusted DOM parser and reconstruct it, or use a well-tested sanitization library to handle such transformations. Since we are restricted to edits within the provided code, the safest approach is to modify `htmlPrefilter` to avoid using the regex to expand self-closing tags. The best solution is to leave the input HTML unchanged, or, if possible, use a DOM approach to parse and serialize HTML fragments safely. However, since we cannot introduce a new complex parser and can only add well-known imports, we should make `htmlPrefilter` a no-op (return the input unchanged) or, if possible, use a well-known library such as DOMPurify to safely parse and serialize the HTML.

**Steps:**
- In `sourcefiles/modern/plugins/jquery/jquery-2.2.4.js`, replace the body of `htmlPrefilter` so that it simply returns `html` (no-op).
- Optionally, add a comment explaining the change for future maintainers.
- No additional imports are needed for a no-op.
- This change avoids expanding self-closing tags and is safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
