### PR TITLE
Potential fix for code scanning alert no. 59: Unsafe jQuery plugin

### DIFF
--- a/sourcefiles/modern/plugins/jquery/jquery-ui-1.12.1.js
+++ b/sourcefiles/modern/plugins/jquery/jquery-ui-1.12.1.js
@@ -8847,7 +8847,12 @@ $.extend( Datepicker.prototype, {
 		var altFormat, date, dateStr,
 			altField = this._get( inst, "altField" );
 
-		if ( altField ) { // update alternate field too
+		// Mitigation for potential XSS: only allow altField as a selector, not as HTML
+		if (
+			typeof altField === "string" &&
+			altField.length > 0 &&
+			altField.trim().charAt(0) !== "<"
+		) { // update alternate field too
 			altFormat = this._get( inst, "altFormat" ) || this._get( inst, "dateFormat" );
 			date = this._getDate( inst );
 			dateStr = this.formatDate( altFormat, date, this._getFormatConfig( inst ) );


### PR DESCRIPTION
Potential fix for [https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/59](https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/59)

To fix the problem, we should ensure that the `altField` option can never be interpreted as a HTML string by jQuery. The safest way is to ensure that only a valid selector string is processed, and to avoid passing user-controlled strings that could be parsed as HTML. Specifically, before using `$( altField )`, we should verify that `altField` is a string that does NOT start with `<`, and if it does, we should not use it, or alternatively, escape it or ignore it. Additionally, we should document in comments that `altField` should not accept arbitrary user input and must be a selector, not HTML.

The best minimal fix within the file is:
- In the `_updateAlternate` method (lines around 8846-8856), before using `$( altField )`, check that `altField` is a string and does not start with `<`.
- If it does start with `<`, skip updating the alternate field or throw an error.
- Add a comment documenting the reason for this check.

This fix should be implemented in the region of `_updateAlternate` in sourcefiles/modern/plugins/jquery/jquery-ui-1.12.1.js.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
