### PR TITLE
Potential fix for code scanning alert no. 44: DOM text reinterpreted as HTML

### DIFF
--- a/sourcefiles/modern/plugins/bootstrap/js/bootstrap.js
+++ b/sourcefiles/modern/plugins/bootstrap/js/bootstrap.js
@@ -773,7 +773,7 @@ if (typeof jQuery === 'undefined') {
       selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    var $parent = selector && $(selector)
+    var $parent = selector && $(document).find(selector)
 
     return $parent && $parent.length ? $parent : $this.parent()
   }


### PR DESCRIPTION
Potential fix for [https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/44](https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/security/code-scanning/44)

To fix the issue, we need to make sure that the value extracted from `data-target` (or, if not present, from `href`) is only ever interpreted as a CSS selector, and never as HTML. The most robust way is to use `document.querySelector` or jQuery's `find()` method on a safe ancestor, as these only accept valid selectors and do not interpret HTML. Alternatively, we can validate that `selector` is a valid CSS selector (e.g., it starts with `#` or `.` and does not contain suspicious characters).

In the context of Bootstrap, the safest fix is to ensure that the code never passes potentially unsafe user input directly to `$()`. Instead, we should only treat `selector` as a selector, not as HTML, and if it's invalid or missing, gracefully fall back. In practice, we can use `document.querySelector` or restrict the selector to IDs by checking that it starts with `#`, or we can use `$.find` on `document` to ensure only a selector is used.

The main change is in the `getParent` function: replace `var $parent = selector && $(selector)` with something like `var $parent = selector && $(document).find(selector)`, which avoids HTML interpretation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
